### PR TITLE
Added support for passing multiple platforms to the build_sdk step on CI

### DIFF
--- a/build_tools/cross_build.py
+++ b/build_tools/cross_build.py
@@ -69,28 +69,31 @@ def load_platform_sdks(path):
         return json.load(f)
 
 
-def merge_platform_sdks(defold_root, platform):
-    """Merge public platform SDK mappings with the private mapping for platform.
+def merge_platform_sdks(defold_root, platforms):
+    """Merge public SDK mappings with private mappings for one or more platforms.
 
-    Private repositories can contain SDK mappings for multiple platforms. A
-    cross build should only expose the mapping for the target platform being
-    built, while keeping all public mappings from the base repository.
+    Private repositories can contain mappings for additional platforms. Only
+    expose the requested private mappings, keeping all public mappings from the
+    base repository. A single platform string is accepted for cross builds.
     """
     platform_sdks = load_platform_sdks(get_platform_sdks_path(defold_root))
 
-    private_root = get_platform_root(platform) if platform else ''
-    if private_root:
-        private_platform_sdks_path = get_platform_sdks_path(private_root)
-        if os.path.exists(private_platform_sdks_path):
-            private_platform_sdks = load_platform_sdks(private_platform_sdks_path)
-            if platform in private_platform_sdks:
-                platform_sdks[platform] = private_platform_sdks[platform]
+    if isinstance(platforms, str):
+        platforms = [platforms]
+    for platform in platforms or []:
+        private_root = get_platform_root(platform) if platform else ''
+        if private_root:
+            private_platform_sdks_path = get_platform_sdks_path(private_root)
+            if os.path.exists(private_platform_sdks_path):
+                private_platform_sdks = load_platform_sdks(private_platform_sdks_path)
+                if platform in private_platform_sdks:
+                    platform_sdks[platform] = private_platform_sdks[platform]
 
     return platform_sdks
 
 
-def write_merged_platform_sdks(defold_root, platform, output_path):
-    platform_sdks = merge_platform_sdks(defold_root, platform)
+def write_merged_platform_sdks(defold_root, platforms, output_path):
+    platform_sdks = merge_platform_sdks(defold_root, platforms)
     with open(output_path, 'w') as f:
         json.dump(platform_sdks, f, indent=4)
         f.write('\n')

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -494,6 +494,7 @@ def build_sdk(channel, platforms=None):
     cmd_opts = []
     cmd_opts.append("--channel=%s" % channel)
     if platforms:
+        platforms = ','.join(platform.strip() for platform in platforms.split(','))
         cmd_opts.append("--platforms=%s" % platforms)
 
     cmd = ' '.join(cmd_args + cmd_opts)

--- a/ci/ci.py
+++ b/ci/ci.py
@@ -489,12 +489,12 @@ def gen_release_notes(channel):
     elif not notes_json_exists:
         print("::warning::No release notes generated for %s on '%s' - shipping without them" % (version, channel))
 
-def build_sdk(channel, platform=None):
+def build_sdk(channel, platforms=None):
     cmd_args = ('"%s" scripts/build.py install_release_dependencies build_sdk' % sys.executable).split()
     cmd_opts = []
     cmd_opts.append("--channel=%s" % channel)
-    if platform:
-        cmd_opts.append("--platform=%s" % platform)
+    if platforms:
+        cmd_opts.append("--platforms=%s" % platforms)
 
     cmd = ' '.join(cmd_args + cmd_opts)
     call(cmd)
@@ -549,6 +549,7 @@ def main(argv):
     parser = ArgumentParser()
     parser.add_argument('commands', nargs="+", help="The command to execute (engine, build-editor, test-editor, archive-editor, gen-release-notes, bob, test-bob, sdk, install, smoke, should-release, requires-release-notes, should-build-platform, should-build-private-platform)")
     parser.add_argument("--platform", dest="platform", help="Platform to build for (when building the engine)")
+    parser.add_argument("--platforms", dest="platforms", help="Comma-separated platforms to include in the combined SDK")
     parser.add_argument("--with-asan", dest="with_asan", action='store_true', help="")
     parser.add_argument("--with-ubsan", dest="with_ubsan", action='store_true', help="")
     parser.add_argument("--with-tsan", dest="with_tsan", action='store_true', help="")
@@ -646,7 +647,7 @@ def main(argv):
         elif command == "test-bob":
             test_bob(channel)
         elif command == "sdk":
-            build_sdk(channel, platform)
+            build_sdk(channel, args.platforms or platform)
         elif command == "smoke":
             smoke_test()
         elif command == "install":

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -596,6 +596,7 @@ class Configuration(object):
                  defold_home = None,
                  dynamo_home = None,
                  target_platform = None,
+                 sdk_platforms = None,
                  skip_tests = False,
                  test_device = None,
                  ios_identity = None,
@@ -650,6 +651,7 @@ class Configuration(object):
         self.defold_root = os.getcwd()
         self.host = get_host_platform()
         self.target_platform = target_platform
+        self.sdk_platforms = sdk_platforms
         self.sdk_info = None
 
         self.build_utility = BuildUtility.BuildUtility(self.target_platform, self.host, self.dynamo_home)
@@ -3058,15 +3060,18 @@ class Configuration(object):
         root = urlparse(self.get_archive_path()).path[1:]
         base_prefix = os.path.join(root, sha1)
 
-        # When a public checkout has a private platform added, only merge the
-        # requested private platform SDK. Public releases still merge all SDKs.
-        private_platforms = build_private.get_target_platforms()
-        if build_private.is_repo_private():
-            platforms = private_platforms
-        elif self.target_platform in private_platforms:
-            platforms = [self.target_platform]
+        if self.sdk_platforms:
+            platforms = self.sdk_platforms
         else:
-            platforms = get_target_platforms()
+            # When a public checkout has a private platform added, only merge the
+            # requested private platform SDK. Public releases still merge all SDKs.
+            private_platforms = build_private.get_target_platforms()
+            if build_private.is_repo_private():
+                platforms = private_platforms
+            elif self.target_platform in private_platforms:
+                platforms = [self.target_platform]
+            else:
+                platforms = get_target_platforms()
         print("Building combined SDK from platform SDK archives:", platforms)
 
         zipmerge_path = shutil.which('zipmerge')
@@ -4119,6 +4124,10 @@ To pass on arbitrary options to waf/CMake: build.py OPTIONS COMMANDS -- BUILD_OP
                       default = None,
                       help = 'Target platform. Defaults to the host platform. With add_private_repo, this may be a new private platform to write to .defold-platforms')
 
+    parser.add_option('--platforms', dest='sdk_platforms',
+                      default = None,
+                      help = 'Comma-separated target platforms to include with build_sdk')
+
     parser.add_option('--skip-tests', dest='skip_tests',
                       action = 'store_true',
                       default = False,
@@ -4312,6 +4321,19 @@ To pass on arbitrary options to waf/CMake: build.py OPTIONS COMMANDS -- BUILD_OP
     if options.target_platform and options.target_platform not in known_platforms and not is_add_private_repo:
         parser.error("option --platform: invalid choice: %r (choose from %s)" % (options.target_platform, ', '.join(known_platforms)))
 
+    sdk_platforms = None
+    if options.sdk_platforms is not None:
+        if 'build_sdk' not in args:
+            parser.error("option --platforms may only be used with build_sdk")
+        sdk_platforms = [platform.strip() for platform in options.sdk_platforms.split(',') if platform.strip()]
+        if not sdk_platforms:
+            parser.error("option --platforms requires at least one platform")
+        unknown_platforms = [platform for platform in sdk_platforms if platform not in known_platforms]
+        if unknown_platforms:
+            parser.error("option --platforms: invalid choice: %r (choose from %s)" % (', '.join(unknown_platforms), ', '.join(known_platforms)))
+        if len(sdk_platforms) != len(set(sdk_platforms)):
+            parser.error("option --platforms contains duplicate platforms")
+
     private_platform = None
     if is_add_private_repo:
         private_platform = options.target_platform or get_host_platform()
@@ -4329,6 +4351,7 @@ To pass on arbitrary options to waf/CMake: build.py OPTIONS COMMANDS -- BUILD_OP
 
     c = Configuration(dynamo_home = os.environ.get('DYNAMO_HOME', None),
                       target_platform = target_platform,
+                      sdk_platforms = sdk_platforms,
                       skip_tests = options.skip_tests,
                       test_device = options.test_device,
                       ios_identity = options.ios_identity,

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3118,7 +3118,7 @@ class Configuration(object):
 
         print("Upload platform sdks mappings")
         platform_sdks_path = join(tempdir, 'platform.sdks.json')
-        write_merged_platform_sdks(self.defold_root, self.target_platform, platform_sdks_path)
+        write_merged_platform_sdks(self.defold_root, platforms, platform_sdks_path)
         self.upload_to_archive(platform_sdks_path, '%s/platform.sdks.json' % sdkurl)
 
         self.wait_uploads()

--- a/scripts/test_build_sdk.py
+++ b/scripts/test_build_sdk.py
@@ -1,0 +1,136 @@
+# Copyright 2020-2026 The Defold Foundation
+# Licensed under the Defold License version 1.0
+
+import contextlib
+import io
+import json
+import shlex
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'ci'))
+
+import build
+import ci
+import cross_build
+
+
+class BuildSdkTests(unittest.TestCase):
+    def setUp(self):
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        self.root = Path(temporary_directory.name)
+        self.public_sdks = {'x86_64-linux': ['linux', 'latest']}
+        self.private_sdks = {
+            'arm64-private': ['private-arm', '1'],
+            'x86_64-private': ['private-x86', '2'],
+        }
+        self.write_json('share/platform.sdks.json', self.public_sdks)
+        self.write_json('private-a/share/platform.sdks.json', {
+            'arm64-private': self.private_sdks['arm64-private'],
+            'arm64-unselected': ['unselected', '3'],
+            'x86_64-linux': ['do-not-override', '4'],
+        })
+        self.write_json('private-b/share/platform.sdks.json', {
+            'x86_64-private': self.private_sdks['x86_64-private'],
+        })
+        config_path = self.write_json('.defold-platforms', {
+            'arm64-private': {'root': str(self.root / 'private-a')},
+            'arm64-unselected': {'root': str(self.root / 'private-a')},
+            'x86_64-private': {'root': str(self.root / 'private-b')},
+        })
+        config_patch = mock.patch.object(cross_build, 'get_platforms_config_path', return_value=config_path)
+        config_patch.start()
+        self.addCleanup(config_patch.stop)
+
+    def write_json(self, relative_path, data):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data))
+        return path
+
+    def test_merge_selected_platforms_from_multiple_private_repositories(self):
+        platform_sdks = cross_build.merge_platform_sdks(
+            self.root, ['x86_64-linux', 'arm64-private', 'x86_64-private'])
+        self.assertEqual(self.public_sdks | self.private_sdks, platform_sdks)
+
+    def test_single_target_keeps_other_private_mappings_out(self):
+        output_path = self.root / 'platform.sdks.json'
+        cross_build.write_merged_platform_sdks(self.root, 'arm64-private', output_path)
+        self.assertEqual(
+            self.public_sdks | {'arm64-private': self.private_sdks['arm64-private']},
+            json.loads(output_path.read_text()))
+
+    def test_no_private_targets_keeps_public_mappings(self):
+        for platforms in (None, [], ['x86_64-linux']):
+            with self.subTest(platforms=platforms):
+                self.assertEqual(self.public_sdks, cross_build.merge_platform_sdks(self.root, platforms))
+
+    def test_combined_sdk_uploads_metadata_for_the_archived_platforms(self):
+        cases = (
+            (['arm64-private', 'x86_64-private'], 'x86_64-linux', False, list(self.private_sdks)),
+            (None, 'x86_64-linux', True, list(self.private_sdks)),
+            (None, 'arm64-private', False, ['arm64-private']),
+            (None, 'x86_64-linux', False, ['x86_64-linux'] + list(self.private_sdks)),
+        )
+        for selected, target, private_repo, expected_platforms in cases:
+            for zipmerge_path in (None, '/test/zipmerge'):
+                with self.subTest(selected=selected, target=target, private_repo=private_repo, zipmerge=zipmerge_path):
+                    configuration = build.Configuration.__new__(build.Configuration)
+                    configuration.defold_root = str(self.root)
+                    configuration.sdk_platforms = selected
+                    configuration.target_platform = target
+                    configuration._git_sha1 = lambda: 'test-sha1'
+                    configuration.get_archive_path = lambda: 's3://test-bucket/archive'
+                    configuration._ziptree = lambda path, directory: path + '.zip'
+                    configuration._create_sha256_signature_file = lambda path: 'defoldsdk.sha256'
+                    configuration.wait_uploads = lambda: None
+                    uploads = {}
+
+                    def upload(path, key):
+                        if key.endswith('/platform.sdks.json'):
+                            uploads[key] = json.loads(Path(path).read_text())
+
+                    configuration.upload_to_archive = upload
+                    with contextlib.ExitStack() as stack:
+                        stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+                        stack.enter_context(mock.patch.object(build.shutil, 'which', return_value=zipmerge_path))
+                        stack.enter_context(mock.patch.object(build.build_private, 'is_repo_private', return_value=private_repo))
+                        stack.enter_context(mock.patch.object(build.build_private, 'get_target_platforms', return_value=list(self.private_sdks)))
+                        stack.enter_context(mock.patch.object(build, 'get_target_platforms', return_value=['x86_64-linux'] + list(self.private_sdks)))
+                        merge_tree = stack.enter_context(mock.patch.object(build.sdk_merge, 'build_combined_sdk_tree'))
+                        merge_zip = stack.enter_context(mock.patch.object(build.sdk_merge, 'build_combined_sdk_zip'))
+                        configuration.build_sdk()
+
+                    merge = merge_zip if zipmerge_path else merge_tree
+                    self.assertEqual(expected_platforms, merge.call_args.kwargs['platforms'])
+                    expected_sdks = self.public_sdks | {
+                        platform: self.private_sdks[platform]
+                        for platform in expected_platforms if platform in self.private_sdks
+                    }
+                    self.assertEqual({'test-sha1/engine/platform.sdks.json': expected_sdks}, uploads)
+
+
+class CiSdkTests(unittest.TestCase):
+    def test_platform_list_is_forwarded_as_one_shell_argument(self):
+        for platforms in ('x86_64-linux,arm64-linux', 'x86_64-linux, arm64-linux', ' x86_64-linux ,\tarm64-linux\n'):
+            with self.subTest(platforms=platforms), mock.patch.object(ci, 'call') as call:
+                ci.build_sdk('dev', platforms)
+                self.assertEqual([
+                    sys.executable, 'scripts/build.py', 'install_release_dependencies', 'build_sdk',
+                    '--channel=dev', '--platforms=x86_64-linux,arm64-linux',
+                ], shlex.split(call.call_args.args[0]))
+
+    def test_omitted_platforms_keep_default_selection(self):
+        with mock.patch.object(ci, 'call') as call:
+            ci.build_sdk('dev')
+        self.assertEqual([
+            sys.executable, 'scripts/build.py', 'install_release_dependencies', 'build_sdk', '--channel=dev',
+        ], shlex.split(call.call_args.args[0]))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fix allows us to pass multiple platforms at once to the build_sdk step

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
