### PR TITLE
Fix native access warnings when running Bob

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
@@ -540,7 +540,11 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
     outputs.file("${project.bobDir}/dist/bob-light.jar")
 
     manifest {
-        def attrs = ['Main-Class': 'com.dynamo.bob.Bob', 'is-bob-light': 'true']
+        def attrs = [
+                'Main-Class': 'com.dynamo.bob.Bob',
+                'Enable-Native-Access': 'ALL-UNNAMED',
+                'is-bob-light': 'true'
+        ]
         if (privateBobPluginClassPath) {
             attrs['Class-Path'] = privateBobPluginClassPath
         }
@@ -773,6 +777,7 @@ task createBobJar(dependsOn: [compileBobLight, createExternalLibsBuiltinsJar, cr
                 zipOutputStream.setMethod(compressionMethod)
                 def manifestAttributes = [
                         'Main-Class': 'com.dynamo.bob.Bob',
+                        'Enable-Native-Access': 'ALL-UNNAMED',
                         'Gradle-Version': gradle.gradleVersion,
                         'Created-By': "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})"
                 ]


### PR DESCRIPTION
Bob and Bob Light now run without Java’s native access warning when launched with `java -jar` on Java 24 and later, without requiring additional JVM options.

### Technical changes

- Add `Enable-Native-Access: ALL-UNNAMED` to both JAR manifests.
- Classpath and embedded launches still require native access to be enabled by the host JVM.
- Verified both packaged JARs on macOS arm64 with Java 25.0.1 and `--illegal-native-access=deny`: the `clean` command completed and `ModelImporterJni` loaded without native access warnings.

This addresses the following warning:

```text
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.dynamo.bob.pipeline.ModelImporterJni in an unnamed module (file:/home/runner/work/tower-escape/tower-escape/.defold/bob.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```