### PR TITLE
Fix accumulated ambient light over collections

### DIFF
--- a/engine/engine/src/engine.cpp
+++ b/engine/engine/src/engine.cpp
@@ -2146,9 +2146,9 @@ bail:
                 // Don't render while iconified
                 if (!dmGraphics::GetWindowStateParam(engine->m_GraphicsContext, WINDOW_STATE_ICONIFIED) && do_render)
                 {
-                    // Update renderer with current time since engine start and frame delta-time.
+                    // Begin the renderer frame with current time since engine start and frame delta-time.
                     // Use the same dt that is passed into script updates and the accumulated engine time.
-                    dmRender::SetFrameTime(engine->m_RenderContext, engine->m_Stats.m_TotalTime + dt, dt);
+                    dmRender::BeginFrame(engine->m_RenderContext, engine->m_Stats.m_TotalTime + dt, dt);
 
                     // Call pre render functions for extensions, if available.
                     // We do it here before we render rest of the frame

--- a/engine/gamesys/src/gamesys/components/comp_light.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_light.cpp
@@ -37,6 +37,7 @@ namespace dmGameSystem
         }
         dmRender::HRenderContext m_RenderContext;
         dmResource::HFactory     m_Factory;
+        dmVMath::Vector3         m_AmbientLight;
         uint32_t                 m_MaxLightCount;
     };
 
@@ -45,8 +46,10 @@ namespace dmGameSystem
         dmGameObject::HInstance  m_Instance;
         LightResource*           m_LightResource;
         dmRender::HLightInstance m_LightInstance;
-        uint16_t                 m_AddedToUpdate : 1;
-        uint16_t                                 : 15;
+        dmVMath::Vector3         m_AmbientContribution;
+        uint16_t                 m_AddedToUpdate              : 1;
+        uint16_t                 m_AmbientContributionActive  : 1;
+        uint16_t                                                  : 14;
     };
 
     struct LightWorld
@@ -79,6 +82,43 @@ namespace dmGameSystem
 
         dmVMath::Vector4 color = dmRender::GetLightColor(context->m_RenderContext, prototype);
         return dmVMath::Vector3(color.getXYZ()) * dmRender::GetLightIntensity(context->m_RenderContext, prototype);
+    }
+
+    static bool AmbientContributionEquals(const dmVMath::Vector3& a, const dmVMath::Vector3& b)
+    {
+        return a.getX() == b.getX() && a.getY() == b.getY() && a.getZ() == b.getZ();
+    }
+
+    static void SetAmbientContribution(LightContext* context, LightComponent* light, const dmVMath::Vector3& contribution)
+    {
+        // Avoid subtracting and re-adding an unchanged contribution every frame. Besides
+        // unnecessary work, doing so can perturb the accumulated value through rounding.
+        if (light->m_AmbientContributionActive && AmbientContributionEquals(light->m_AmbientContribution, contribution))
+        {
+            return;
+        }
+
+        if (light->m_AmbientContributionActive)
+        {
+            context->m_AmbientLight -= light->m_AmbientContribution;
+        }
+        context->m_AmbientLight += contribution;
+        light->m_AmbientContribution = contribution;
+        light->m_AmbientContributionActive = 1;
+        dmRender::SetAmbientLight(context->m_RenderContext, context->m_AmbientLight);
+    }
+
+    static void ClearAmbientContribution(LightContext* context, LightComponent* light)
+    {
+        if (!light->m_AmbientContributionActive)
+        {
+            return;
+        }
+
+        context->m_AmbientLight -= light->m_AmbientContribution;
+        light->m_AmbientContribution = dmVMath::Vector3(0.0f, 0.0f, 0.0f);
+        light->m_AmbientContributionActive = 0;
+        dmRender::SetAmbientLight(context->m_RenderContext, context->m_AmbientLight);
     }
 
     static bool CreateRenderLightInstance(LightContext* context, LightComponent* light)
@@ -151,6 +191,8 @@ namespace dmGameSystem
                     dmRender::DeleteLightInstance(context->m_RenderContext, light->m_LightInstance);
                 }
 
+                ClearAmbientContribution(context, light);
+
                 delete light;
                 return dmGameObject::CREATE_RESULT_OK;
             }
@@ -171,7 +213,6 @@ namespace dmGameSystem
         LightContext* context = (LightContext*)params.m_Context;
 
         uint32_t num_components = world->m_Components.Size();
-        dmVMath::Vector3 ambient_light(0.0f, 0.0f, 0.0f);
         for (uint32_t i = 0; i < num_components; ++i)
         {
             LightComponent* light = world->m_Components[i];
@@ -190,9 +231,12 @@ namespace dmGameSystem
                     dmRender::DeleteLightInstance(context->m_RenderContext, light->m_LightInstance);
                     light->m_LightInstance = 0;
                 }
-                ambient_light += AmbientContribution(context, light->m_LightResource);
+                SetAmbientContribution(context, light, AmbientContribution(context, light->m_LightResource));
                 continue;
             }
+
+            // The resource may have been reloaded from ambient to a buffered light type.
+            ClearAmbientContribution(context, light);
 
             if (light->m_LightInstance == 0 && !CreateRenderLightInstance(context, light))
             {
@@ -209,7 +253,6 @@ namespace dmGameSystem
 
             dmRender::SetLightInstance(context->m_RenderContext, light->m_LightInstance, position, rotation, scale);
         }
-        dmRender::SetAmbientLight(context->m_RenderContext, ambient_light);
         return dmGameObject::UPDATE_RESULT_OK;
     }
 

--- a/engine/gamesys/src/gamesys/components/comp_light.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_light.cpp
@@ -37,7 +37,6 @@ namespace dmGameSystem
         }
         dmRender::HRenderContext m_RenderContext;
         dmResource::HFactory     m_Factory;
-        dmVMath::Vector3         m_AmbientLight;
         uint32_t                 m_MaxLightCount;
     };
 
@@ -46,10 +45,8 @@ namespace dmGameSystem
         dmGameObject::HInstance  m_Instance;
         LightResource*           m_LightResource;
         dmRender::HLightInstance m_LightInstance;
-        dmVMath::Vector3         m_AmbientContribution;
-        uint16_t                 m_AddedToUpdate              : 1;
-        uint16_t                 m_AmbientContributionActive  : 1;
-        uint16_t                                                  : 14;
+        uint16_t                 m_AddedToUpdate : 1;
+        uint16_t                                 : 15;
     };
 
     struct LightWorld
@@ -65,60 +62,6 @@ namespace dmGameSystem
         world->m_Components.SetCapacity(comp_count);
         *params.m_World = world;
         return dmGameObject::CREATE_RESULT_OK;
-    }
-
-    static dmRender::LightType LightType(LightContext* context, LightResource* light_resource)
-    {
-        return dmRender::GetLightType(context->m_RenderContext, GetLightPrototype(light_resource));
-    }
-
-    static dmVMath::Vector3 AmbientContribution(LightContext* context, LightResource* light_resource)
-    {
-        dmRender::HLightPrototype prototype = GetLightPrototype(light_resource);
-        if (dmRender::GetLightType(context->m_RenderContext, prototype) != dmRender::LIGHT_TYPE_AMBIENT)
-        {
-            return dmVMath::Vector3(0.0f, 0.0f, 0.0f);
-        }
-
-        dmVMath::Vector4 color = dmRender::GetLightColor(context->m_RenderContext, prototype);
-        return dmVMath::Vector3(color.getXYZ()) * dmRender::GetLightIntensity(context->m_RenderContext, prototype);
-    }
-
-    static bool AmbientContributionEquals(const dmVMath::Vector3& a, const dmVMath::Vector3& b)
-    {
-        return a.getX() == b.getX() && a.getY() == b.getY() && a.getZ() == b.getZ();
-    }
-
-    static void SetAmbientContribution(LightContext* context, LightComponent* light, const dmVMath::Vector3& contribution)
-    {
-        // Avoid subtracting and re-adding an unchanged contribution every frame. Besides
-        // unnecessary work, doing so can perturb the accumulated value through rounding.
-        if (light->m_AmbientContributionActive && AmbientContributionEquals(light->m_AmbientContribution, contribution))
-        {
-            return;
-        }
-
-        if (light->m_AmbientContributionActive)
-        {
-            context->m_AmbientLight -= light->m_AmbientContribution;
-        }
-        context->m_AmbientLight += contribution;
-        light->m_AmbientContribution = contribution;
-        light->m_AmbientContributionActive = 1;
-        dmRender::SetAmbientLight(context->m_RenderContext, context->m_AmbientLight);
-    }
-
-    static void ClearAmbientContribution(LightContext* context, LightComponent* light)
-    {
-        if (!light->m_AmbientContributionActive)
-        {
-            return;
-        }
-
-        context->m_AmbientLight -= light->m_AmbientContribution;
-        light->m_AmbientContribution = dmVMath::Vector3(0.0f, 0.0f, 0.0f);
-        light->m_AmbientContributionActive = 0;
-        dmRender::SetAmbientLight(context->m_RenderContext, context->m_AmbientLight);
     }
 
     static bool CreateRenderLightInstance(LightContext* context, LightComponent* light)
@@ -144,8 +87,6 @@ namespace dmGameSystem
         LightWorld* world = (LightWorld*) params.m_World;
         LightContext* context = (LightContext*)params.m_Context;
         LightResource* light_resource = (LightResource*) params.m_Resource;
-        bool is_ambient = LightType(context, light_resource) == dmRender::LIGHT_TYPE_AMBIENT;
-
         if (world->m_Components.Full())
         {
             ShowFullBufferError("Light", LIGHT_MAX_COUNT_KEY, world->m_Components.Capacity());
@@ -158,7 +99,7 @@ namespace dmGameSystem
         light->m_Instance      = params.m_Instance;
         light->m_LightResource = light_resource;
 
-        if (!is_ambient && !CreateRenderLightInstance(context, light))
+        if (!CreateRenderLightInstance(context, light))
         {
             delete light;
             return dmGameObject::CREATE_RESULT_TOO_MANY_COMPONENTS;
@@ -191,8 +132,6 @@ namespace dmGameSystem
                     dmRender::DeleteLightInstance(context->m_RenderContext, light->m_LightInstance);
                 }
 
-                ClearAmbientContribution(context, light);
-
                 delete light;
                 return dmGameObject::CREATE_RESULT_OK;
             }
@@ -221,23 +160,6 @@ namespace dmGameSystem
                 continue;
             }
 
-            bool is_ambient = LightType(context, light->m_LightResource) == dmRender::LIGHT_TYPE_AMBIENT;
-            if (is_ambient)
-            {
-                if (light->m_LightInstance)
-                {
-                    // The resource may have been reloaded from a buffered light type
-                    // to ambient. Ambient lights are accumulated instead of instanced.
-                    dmRender::DeleteLightInstance(context->m_RenderContext, light->m_LightInstance);
-                    light->m_LightInstance = 0;
-                }
-                SetAmbientContribution(context, light, AmbientContribution(context, light->m_LightResource));
-                continue;
-            }
-
-            // The resource may have been reloaded from ambient to a buffered light type.
-            ClearAmbientContribution(context, light);
-
             if (light->m_LightInstance == 0 && !CreateRenderLightInstance(context, light))
             {
                 continue;
@@ -252,6 +174,23 @@ namespace dmGameSystem
             float scale = dmMath::Min(scale_x, dmMath::Min(scale_y, scale_z));
 
             dmRender::SetLightInstance(context->m_RenderContext, light->m_LightInstance, position, rotation, scale);
+        }
+        return dmGameObject::UPDATE_RESULT_OK;
+    }
+
+    static dmGameObject::UpdateResult CompLightRender(const dmGameObject::ComponentsRenderParams& params)
+    {
+        LightWorld* world = (LightWorld*) params.m_World;
+        LightContext* context = (LightContext*) params.m_Context;
+
+        uint32_t num_components = world->m_Components.Size();
+        for (uint32_t i = 0; i < num_components; ++i)
+        {
+            LightComponent* light = world->m_Components[i];
+            if (light->m_AddedToUpdate && light->m_LightInstance)
+            {
+                dmRender::SubmitLightInstance(context->m_RenderContext, light->m_LightInstance);
+            }
         }
         return dmGameObject::UPDATE_RESULT_OK;
     }
@@ -276,6 +215,7 @@ namespace dmGameSystem
         ComponentTypeSetDestroyFn(type, CompLightDestroy);
         ComponentTypeSetAddToUpdateFn(type, CompLightAddToUpdate);
         ComponentTypeSetLateUpdateFn(type, CompLightLateUpdate);
+        ComponentTypeSetRenderFn(type, CompLightRender);
         ComponentTypeSetGetFn(type, CompLightGetComponent);
 
         return dmGameObject::RESULT_OK;

--- a/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light.collection
@@ -1,0 +1,5 @@
+name: "ambient_light"
+instances {
+  id: "ambient_light"
+  prototype: "/light/valid_ambient_light.go"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light.collection
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light.collection
@@ -3,3 +3,7 @@ instances {
   id: "ambient_light"
   prototype: "/light/valid_ambient_light.go"
 }
+instances {
+  id: "point_light"
+  prototype: "/light/valid_point_light.go"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light.collectionproxy
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light.collectionproxy
@@ -1,0 +1,1 @@
+collection: "/collection_proxy/ambient_light.collection"

--- a/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light_root.go
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/ambient_light_root.go
@@ -1,0 +1,4 @@
+components {
+  id: "collectionproxy"
+  component: "/collection_proxy/ambient_light.collectionproxy"
+}

--- a/engine/gamesys/src/gamesys/test/collection_proxy/build.inputs
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/build.inputs
@@ -1,5 +1,6 @@
 /collection_proxy/input_consume_no.go
 /collection_proxy/input_consume_yes.go
+/collection_proxy/ambient_light_root.go
 /collection_proxy/release_dynamic_resource_root.go
 /collection_proxy/release_dynamic_resource_target.collection
 /collection_proxy/script_load_api.go

--- a/engine/gamesys/src/gamesys/test/collection_proxy/build.inputs
+++ b/engine/gamesys/src/gamesys/test/collection_proxy/build.inputs
@@ -1,6 +1,7 @@
 /collection_proxy/input_consume_no.go
 /collection_proxy/input_consume_yes.go
 /collection_proxy/ambient_light_root.go
+/material/light_buffer.material
 /collection_proxy/release_dynamic_resource_root.go
 /collection_proxy/release_dynamic_resource_target.collection
 /collection_proxy/script_load_api.go

--- a/engine/gamesys/src/gamesys/test/light/build.inputs
+++ b/engine/gamesys/src/gamesys/test/light/build.inputs
@@ -1,5 +1,6 @@
 /light/test_comp.go
 /light/valid_ambient_light.go
+/material/light_buffer.material
 /light/valid_directional_light.go
 /light/valid_point_light.go
 /light/valid_spot_light.go

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -1443,6 +1443,33 @@ TEST_F(CollectionProxyComponentTest, CollectionProxySetCollectionLoadInitialize)
     lua_pop(L, 1);
 }
 
+TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProxy)
+{
+    dmRender::RenderContext* render_ctx = (dmRender::RenderContext*) m_RenderContext;
+    ASSERT_NE((void*)0, render_ctx);
+
+    dmGameObject::HInstance proxy_go = Spawn(m_Factory, m_Collection, "/collection_proxy/ambient_light_root.goc", dmHashString64("/proxy"), 0,
+                                              Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
+    ASSERT_NE((void*)0, proxy_go);
+
+    CollectionProxyComponentRef proxy = GetCollectionProxyComponentRef(proxy_go, dmHashString64("collectionproxy"));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyLoad(proxy.m_World, proxy.m_Component, 0, 0));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyInitialize(proxy.m_World, proxy.m_Component));
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyEnable(proxy.m_World, proxy.m_Component));
+
+    UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+    // The empty parent light world is updated after the proxied collection and must not
+    // overwrite the ambient contribution produced by the child light world.
+    ASSERT_VEC3(Vector3(0.5f, 1.0f, 1.5f), render_ctx->m_AmbientLight);
+
+    dmGameObject::Delete(m_Collection, proxy_go, true);
+    UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+    // Destroying the proxy collection must remove its contribution from the shared context.
+    ASSERT_VEC3(Vector3(0.0f, 0.0f, 0.0f), render_ctx->m_AmbientLight);
+}
+
 TEST_F(CollectionProxyComponentTest, ReleaseDynamicResourceFromAnotherCollection)
 {
     // The proxy collection creates the resource, while this parent collection

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -655,6 +655,7 @@ TEST_F(LightResourceTest, AmbientLightsAreCompactedIntoLightInfo)
 
     ASSERT_EQ(ambient_count, render_ctx->m_LightBufferScratch.Size());
 
+    dmRender::BeginFrame(m_RenderContext, 1.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -1480,6 +1481,7 @@ TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProx
 
     UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
 
+    dmRender::BeginFrame(m_RenderContext, 1.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -1493,6 +1495,7 @@ TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProx
     ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyDisable(proxy.m_World, proxy.m_Component));
     UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
 
+    dmRender::BeginFrame(m_RenderContext, 2.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -1506,6 +1509,7 @@ TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProx
     ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyEnable(proxy.m_World, proxy.m_Component));
     UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
 
+    dmRender::BeginFrame(m_RenderContext, 3.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -1517,6 +1521,7 @@ TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProx
     dmGameObject::Delete(m_Collection, proxy_go, true);
     UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
 
+    dmRender::BeginFrame(m_RenderContext, 4.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -10069,6 +10074,7 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUbo)
         ASSERT_VEC3(positions[i], render_ctx->m_LightBufferScratch[i + 1].m_Position);
     }
 
+    dmRender::BeginFrame(m_RenderContext, 1.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -10153,6 +10159,7 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboAfterDelete)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
+    dmRender::BeginFrame(m_RenderContext, 1.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -10169,6 +10176,7 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboAfterDelete)
     DeleteInstance(m_Collection, gos[1]);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
+    dmRender::BeginFrame(m_RenderContext, 2.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);
@@ -10237,6 +10245,7 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboCompute)
         ASSERT_VEC3(positions[i], render_ctx->m_LightBufferScratch[i].m_Position);
     }
 
+    dmRender::BeginFrame(m_RenderContext, 1.0f, m_UpdateContext.m_DT);
     dmRender::RenderListBegin(m_RenderContext);
     ASSERT_TRUE(dmGameObject::Render(m_Collection));
     dmRender::RenderListEnd(m_RenderContext);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -596,23 +596,28 @@ TEST_F(LightResourceTest, LightComponentUpdatesLightBuffer)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    ASSERT_EQ(3u, render_ctx->m_LightBufferScratch.Size());
-    ASSERT_VEC3(Vector3(0.5f, 1.0f, 1.5f), render_ctx->m_AmbientLight);
+    ASSERT_EQ(4u, render_ctx->m_LightBufferScratch.Size());
 
-    // Creation order (point, directional, spot) matches CompLightWorld component order and light buffer indices 0..2
-    const dmRender::LightSTD140& L_point = render_ctx->m_LightBufferScratch[0];
+    // Ambient lights now retain the same per-instance source data as the other
+    // types, but are folded into light_info.xyz instead of the uploaded lights[].
+    const dmRender::LightSTD140& L_ambient = render_ctx->m_LightBufferScratch[0];
+    ASSERT_VEC4(dmVMath::Vector4(0.1f, 0.2f, 0.3f, 1.0f), L_ambient.m_Color);
+    ASSERT_VEC4(dmVMath::Vector4((float) dmRender::LIGHT_TYPE_AMBIENT, 5.0f, 0.0f, 0.0f), L_ambient.m_Params);
+
+    // Creation order matches CompLightWorld component order and light buffer indices 0..3.
+    const dmRender::LightSTD140& L_point = render_ctx->m_LightBufferScratch[1];
     ASSERT_VEC3(pos_point, L_point.m_Position);
     ASSERT_VEC4(dmVMath::Vector4(1.0f, 0.5f, 0.25f, 1.0f), L_point.m_Color);
     ASSERT_VEC4(dmVMath::Vector4(0.0f, 0.0f, 0.0f, 10.0f), L_point.m_DirectionRange);
     ASSERT_VEC4(dmVMath::Vector4((float) dmRender::LIGHT_TYPE_POINT, 2.0f, 0.0f, 0.0f), L_point.m_Params);
 
-    const dmRender::LightSTD140& L_dir = render_ctx->m_LightBufferScratch[1];
+    const dmRender::LightSTD140& L_dir = render_ctx->m_LightBufferScratch[2];
     ASSERT_VEC3(pos_dir, L_dir.m_Position);
     ASSERT_VEC4(dmVMath::Vector4(1.0f, 0.0f, 0.0f, 1.0f), L_dir.m_Color);
     ASSERT_VEC4(dmVMath::Vector4(0.0f, 0.0f, -1.0f, 0.0f), L_dir.m_DirectionRange);
     ASSERT_VEC4(dmVMath::Vector4((float) dmRender::LIGHT_TYPE_DIRECTIONAL, 3.0f, 0.0f, 0.0f), L_dir.m_Params);
 
-    const dmRender::LightSTD140& L_spot = render_ctx->m_LightBufferScratch[2];
+    const dmRender::LightSTD140& L_spot = render_ctx->m_LightBufferScratch[3];
     ASSERT_VEC3(pos_spot, L_spot.m_Position);
     ASSERT_VEC4(dmVMath::Vector4(0.2f, 0.8f, 0.1f, 1.0f), L_spot.m_Color);
     ASSERT_VEC4(dmVMath::Vector4(0.0f, 0.0f, -1.0f, 20.0f), L_spot.m_DirectionRange);
@@ -622,14 +627,14 @@ TEST_F(LightResourceTest, LightComponentUpdatesLightBuffer)
     dmGameObject::SetPosition(go_point, pos_point_moved);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    ASSERT_VEC3(pos_point_moved, render_ctx->m_LightBufferScratch[0].m_Position);
-    ASSERT_VEC3(pos_dir, render_ctx->m_LightBufferScratch[1].m_Position);
-    ASSERT_VEC3(pos_spot, render_ctx->m_LightBufferScratch[2].m_Position);
+    ASSERT_VEC3(pos_point_moved, render_ctx->m_LightBufferScratch[1].m_Position);
+    ASSERT_VEC3(pos_dir, render_ctx->m_LightBufferScratch[2].m_Position);
+    ASSERT_VEC3(pos_spot, render_ctx->m_LightBufferScratch[3].m_Position);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
 
-TEST_F(LightResourceTest, AmbientLightsDoNotUseLightBufferSlots)
+TEST_F(LightResourceTest, AmbientLightsAreCompactedIntoLightInfo)
 {
     dmRender::RenderContext* render_ctx = (dmRender::RenderContext*) m_RenderContext;
     ASSERT_NE((void*)0, render_ctx);
@@ -648,8 +653,20 @@ TEST_F(LightResourceTest, AmbientLightsDoNotUseLightBufferSlots)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    ASSERT_EQ(0u, render_ctx->m_LightBufferScratch.Size());
+    ASSERT_EQ(ambient_count, render_ctx->m_LightBufferScratch.Size());
+
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+
+    dmGameSystem::MaterialResource* material_res = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/light_buffer.materialc", (void**) &material_res));
+    dmRender::ApplyMaterialProgramLightBuffers(m_RenderContext, material_res->m_Material);
+
+    ASSERT_EQ(0u, render_ctx->m_LightBufferUploadScratch.Size());
     ASSERT_VEC3(Vector3(0.5f * ambient_count, 1.0f * ambient_count, 1.5f * ambient_count), render_ctx->m_AmbientLight);
+
+    dmResource::Release(m_Factory, (void*) material_res);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
@@ -675,15 +692,15 @@ TEST_F(LightResourceTest, LightComponentUsesWorldTransform)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    ASSERT_EQ(1u, render_ctx->m_LightBufferScratch.Size());
-    ASSERT_VEC3(dmGameObject::GetWorldPosition(child_light), render_ctx->m_LightBufferScratch[0].m_Position);
-    ASSERT_NEAR(10.0f, render_ctx->m_LightBufferScratch[0].m_DirectionRange.getW(), EPSILON);
+    ASSERT_EQ(2u, render_ctx->m_LightBufferScratch.Size());
+    ASSERT_VEC3(dmGameObject::GetWorldPosition(child_light), render_ctx->m_LightBufferScratch[1].m_Position);
+    ASSERT_NEAR(10.0f, render_ctx->m_LightBufferScratch[1].m_DirectionRange.getW(), EPSILON);
 
     dmGameObject::SetScale(parent, Vector3(2.0f, 3.0f, 4.0f));
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
-    ASSERT_VEC3(dmGameObject::GetWorldPosition(child_light), render_ctx->m_LightBufferScratch[0].m_Position);
-    ASSERT_NEAR(20.0f, render_ctx->m_LightBufferScratch[0].m_DirectionRange.getW(), EPSILON);
+    ASSERT_VEC3(dmGameObject::GetWorldPosition(child_light), render_ctx->m_LightBufferScratch[1].m_Position);
+    ASSERT_NEAR(20.0f, render_ctx->m_LightBufferScratch[1].m_DirectionRange.getW(), EPSILON);
 
     ASSERT_TRUE(dmGameObject::Final(m_Collection));
 }
@@ -1448,6 +1465,10 @@ TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProx
     dmRender::RenderContext* render_ctx = (dmRender::RenderContext*) m_RenderContext;
     ASSERT_NE((void*)0, render_ctx);
 
+    dmGameSystem::MaterialResource* material_res = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/light_buffer.materialc", (void**) &material_res));
+    ASSERT_NE((void*)0, material_res);
+
     dmGameObject::HInstance proxy_go = Spawn(m_Factory, m_Collection, "/collection_proxy/ambient_light_root.goc", dmHashString64("/proxy"), 0,
                                               Point3(0, 0, 0), Quat(0, 0, 0, 1), Vector3(1, 1, 1));
     ASSERT_NE((void*)0, proxy_go);
@@ -1459,15 +1480,52 @@ TEST_F(CollectionProxyComponentTest, AmbientLightAccumulatesAcrossCollectionProx
 
     UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
 
-    // The empty parent light world is updated after the proxied collection and must not
-    // overwrite the ambient contribution produced by the child light world.
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::ApplyMaterialProgramLightBuffers(m_RenderContext, material_res->m_Material);
+
+    // The enabled proxy renders its child collection, which submits the ambient
+    // and point instances before the light buffer snapshot is compacted.
     ASSERT_VEC3(Vector3(0.5f, 1.0f, 1.5f), render_ctx->m_AmbientLight);
+    ASSERT_EQ(1u, render_ctx->m_LightBufferUploadScratch.Size());
+
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyDisable(proxy.m_World, proxy.m_Component));
+    UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::ApplyMaterialProgramLightBuffers(m_RenderContext, material_res->m_Material);
+
+    // The light instance still owns its latest data, but the disabled child is
+    // not rendered and therefore does not submit the instance for this frame.
+    ASSERT_VEC3(Vector3(0.0f, 0.0f, 0.0f), render_ctx->m_AmbientLight);
+    ASSERT_EQ(0u, render_ctx->m_LightBufferUploadScratch.Size());
+
+    ASSERT_EQ(dmGameObject::RESULT_OK, dmGameSystem::CompCollectionProxyEnable(proxy.m_World, proxy.m_Component));
+    UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
+
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::ApplyMaterialProgramLightBuffers(m_RenderContext, material_res->m_Material);
+
+    ASSERT_VEC3(Vector3(0.5f, 1.0f, 1.5f), render_ctx->m_AmbientLight);
+    ASSERT_EQ(1u, render_ctx->m_LightBufferUploadScratch.Size());
 
     dmGameObject::Delete(m_Collection, proxy_go, true);
     UpdateAndPostUpdateCollection(m_Collection, &m_UpdateContext, m_Register);
 
-    // Destroying the proxy collection must remove its contribution from the shared context.
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+    dmRender::ApplyMaterialProgramLightBuffers(m_RenderContext, material_res->m_Material);
+
     ASSERT_VEC3(Vector3(0.0f, 0.0f, 0.0f), render_ctx->m_AmbientLight);
+    ASSERT_EQ(0u, render_ctx->m_LightBufferUploadScratch.Size());
+
+    dmResource::Release(m_Factory, (void*) material_res);
 }
 
 TEST_F(CollectionProxyComponentTest, ReleaseDynamicResourceFromAnotherCollection)
@@ -9980,11 +10038,9 @@ TEST_F(MaterialTest, TestLightBufferSmallerThanProjectMax)
 
 TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUbo)
 {
-    // Spawns multiple point-light components from the same .lightc with distinct transforms, runs the
-    // game-object update (LateUpdate -> SetLightInstance -> scratch), then applies light_buffer.material
-    // (fragment shader sums lights[i].color from LightBuffer) so ApplyMaterialProgramLightBuffers uploads
-    // scratch + active light count into the render light uniform buffer. On the null graphics adapter we
-    // memcmp the UBO backing store against scratch to prove the upload path ran with the expected layout.
+    // Spawns ambient and point-light components, updates their persistent instance data, renders the
+    // collection to submit the visible instances, then applies light_buffer.material. The ambient
+    // instance is folded into light_info.xyz while only point lights are uploaded to lights[].
     dmRender::RenderContext* render_ctx = (dmRender::RenderContext*) m_RenderContext;
     ASSERT_NE((void*)0, render_ctx);
 
@@ -10007,11 +10063,15 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUbo)
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
     // Light data is commited into a scratch buffer before pushing it to the GPU
-    ASSERT_EQ(10u, render_ctx->m_LightBufferScratch.Size());
+    ASSERT_EQ(11u, render_ctx->m_LightBufferScratch.Size());
     for (uint32_t i = 0; i < 10; ++i)
     {
-        ASSERT_VEC3(positions[i], render_ctx->m_LightBufferScratch[i].m_Position);
+        ASSERT_VEC3(positions[i], render_ctx->m_LightBufferScratch[i + 1].m_Position);
     }
+
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
 
     dmGameSystem::MaterialResource* material_res = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/light_buffer.materialc", (void**) &material_res));
@@ -10036,7 +10096,7 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUbo)
     const uint32_t light_data_offset = render_ctx->m_LightBufferDataWriteStart;
     const uint32_t light_data_bytes  = 10u * (uint32_t) sizeof(dmRender::LightSTD140);
     ASSERT_LE(light_data_offset + light_data_bytes, ubo->m_BufferSize);
-    ASSERT_EQ(0, memcmp(ubo->m_Buffer + light_data_offset, render_ctx->m_LightBufferScratch.Begin(), light_data_bytes));
+    ASSERT_EQ(0, memcmp(ubo->m_Buffer + light_data_offset, render_ctx->m_LightBufferUploadScratch.Begin(), light_data_bytes));
 
     dmGameSystem::MaterialResource* small_material_res = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/light_buffer_small.materialc", (void**) &small_material_res));
@@ -10093,6 +10153,10 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboAfterDelete)
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
 
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+
     dmGameSystem::MaterialResource* material_res = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/light_buffer.materialc", (void**) &material_res));
     ASSERT_NE((void*)0, material_res);
@@ -10104,6 +10168,10 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboAfterDelete)
 
     DeleteInstance(m_Collection, gos[1]);
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
 
     dmRender::ApplyMaterialProgramLightBuffers(m_RenderContext, material);
 
@@ -10169,6 +10237,10 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboCompute)
         ASSERT_VEC3(positions[i], render_ctx->m_LightBufferScratch[i].m_Position);
     }
 
+    dmRender::RenderListBegin(m_RenderContext);
+    ASSERT_TRUE(dmGameObject::Render(m_Collection));
+    dmRender::RenderListEnd(m_RenderContext);
+
     dmGameSystem::ComputeResource* compute_res = 0;
     ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/shader/light_buffer.computec", (void**) &compute_res));
     ASSERT_NE((void*)0, compute_res);
@@ -10189,7 +10261,7 @@ TEST_F(MaterialResourceTest, TestLightBufferWriteIntoUboCompute)
     const uint32_t light_data_offset = render_ctx->m_LightBufferDataWriteStart;
     const uint32_t light_data_bytes  = 10u * (uint32_t) sizeof(dmRender::LightSTD140);
     ASSERT_LE(light_data_offset + light_data_bytes, ubo->m_BufferSize);
-    ASSERT_EQ(0, memcmp(ubo->m_Buffer + light_data_offset, render_ctx->m_LightBufferScratch.Begin(), light_data_bytes));
+    ASSERT_EQ(0, memcmp(ubo->m_Buffer + light_data_offset, render_ctx->m_LightBufferUploadScratch.Begin(), light_data_bytes));
 
     dmResource::Release(m_Factory, (void*) compute_res);
     ASSERT_TRUE(dmGameObject::Final(m_Collection));

--- a/engine/render/src/render/light.cpp
+++ b/engine/render/src/render/light.cpp
@@ -120,13 +120,6 @@ namespace dmRender
             return 0;
         }
 
-        // Ambient lights are folded into light_info.xyz and do not allocate
-        // entries in the per-light buffer.
-        if (prototype->m_Type == LIGHT_TYPE_AMBIENT)
-        {
-            return 0;
-        }
-
         // Reached max count.
         if (render_context->m_RenderLightsIndices.Size() >= render_context->m_MaxLightCount || render_context->m_RenderLightsIndices.Remaining() == 0)
         {
@@ -165,7 +158,24 @@ namespace dmRender
                 return;
             }
             render_context->m_RenderLightsIndices.Push(light_instance->m_LightBufferIndex);
+            render_context->m_LightBufferSubmitted[light_instance->m_LightBufferIndex] = 0;
             light_instance->m_LightPrototype = 0;
+            CommitLightInfo(render_context);
+        }
+    }
+
+    void SubmitLightInstance(HRenderContext render_context, HLightInstance instance)
+    {
+        uint16_t light_buffer_index = instance & 0xFFFF;
+        LightInstance* light_instance = light_buffer_index < render_context->m_RenderLights.Size() ? &render_context->m_RenderLights[light_buffer_index] : 0;
+        if (!light_instance || light_instance->m_LightPrototype == 0 || light_instance->m_Version != (instance >> 16))
+        {
+            return;
+        }
+
+        if (!render_context->m_LightBufferSubmitted[light_buffer_index])
+        {
+            render_context->m_LightBufferSubmitted[light_buffer_index] = 1;
             CommitLightInfo(render_context);
         }
     }
@@ -322,7 +332,6 @@ namespace dmRender
         switch (prototype->m_Type)
         {
         case LIGHT_TYPE_AMBIENT:
-            assert(false && "Ambient lights are accumulated in light_info.xyz and should not be written as light instances");
             break;
         case LIGHT_TYPE_DIRECTIONAL:
             direction = world_direction;
@@ -384,29 +393,37 @@ namespace dmRender
 
     static uint32_t CompactLightBufferScratch(HRenderContext render_context)
     {
-        uint32_t active_light_count = render_context->m_RenderLightsIndices.Size();
         render_context->m_LightBufferUploadScratch.SetSize(0);
 
-        if (active_light_count == 0)
+        uint32_t allocated_light_count = render_context->m_RenderLightsIndices.Size();
+        if (render_context->m_LightBufferUploadScratch.Capacity() < allocated_light_count)
         {
-            return 0;
+            render_context->m_LightBufferUploadScratch.SetCapacity(allocated_light_count);
         }
 
-        if (render_context->m_LightBufferUploadScratch.Capacity() < active_light_count)
-        {
-            render_context->m_LightBufferUploadScratch.SetCapacity(active_light_count);
-        }
-
+        dmVMath::Vector3 ambient_light(0.0f, 0.0f, 0.0f);
         uint32_t render_light_count = render_context->m_RenderLights.Size();
         for (uint32_t i = 0; i < render_light_count; ++i)
         {
             const LightInstance* instance = &render_context->m_RenderLights[i];
-            if (instance->m_LightPrototype != 0)
+            if (instance->m_LightPrototype == 0 || !render_context->m_LightBufferSubmitted[i])
             {
-                render_context->m_LightBufferUploadScratch.Push(render_context->m_LightBufferScratch[instance->m_LightBufferIndex]);
+                continue;
+            }
+
+            const LightSTD140& light = render_context->m_LightBufferScratch[instance->m_LightBufferIndex];
+            LightType type = (LightType) (uint32_t) light.m_Params.getX();
+            if (type == LIGHT_TYPE_AMBIENT)
+            {
+                ambient_light += dmVMath::Vector3(light.m_Color.getXYZ()) * light.m_Params.getY();
+            }
+            else
+            {
+                render_context->m_LightBufferUploadScratch.Push(light);
             }
         }
 
+        render_context->m_AmbientLight = ambient_light;
         return render_context->m_LightBufferUploadScratch.Size();
     }
 
@@ -414,15 +431,12 @@ namespace dmRender
     {
         uint32_t active_light_count = CompactLightBufferScratch(render_context);
 
-        if (render_context->m_LightBufferDirtyInfo)
-        {
-            dmVMath::Vector4 info(render_context->m_AmbientLight, (float) active_light_count);
-            dmGraphics::SetUniformBuffer(render_context->m_GraphicsContext,
-                                         render_context->m_LightUniformBuffer,
-                                         render_context->m_LightBufferInfoWriteStart,
-                                         sizeof(info),
-                                         &info);
-        }
+        dmVMath::Vector4 info(render_context->m_AmbientLight, (float) active_light_count);
+        dmGraphics::SetUniformBuffer(render_context->m_GraphicsContext,
+                                     render_context->m_LightUniformBuffer,
+                                     render_context->m_LightBufferInfoWriteStart,
+                                     sizeof(info),
+                                     &info);
 
         // Write compacted light data from the scratch buffer. The shader loops
         // over [0..light_info.w), while light buffer indices may be reused.
@@ -468,17 +482,6 @@ namespace dmRender
         return true;
     }
 
-    void SetAmbientLight(HRenderContext render_context, dmVMath::Vector3 color)
-    {
-        if (render_context->m_AmbientLight.getX() != color.getX() ||
-            render_context->m_AmbientLight.getY() != color.getY() ||
-            render_context->m_AmbientLight.getZ() != color.getZ())
-        {
-            render_context->m_AmbientLight = color;
-            CommitLightInfo(render_context);
-        }
-    }
-
     void SetLightBufferCount(HRenderContext render_context, uint32_t max_lights)
     {
         assert(render_context);
@@ -518,6 +521,12 @@ namespace dmRender
         render_context->m_LightBufferScratch.SetSize(0);
         render_context->m_LightBufferUploadScratch.SetSize(0);
         render_context->m_LightBufferUploadScratch.SetCapacity(0);
+        if (render_context->m_LightBufferSubmitted.Capacity() < max_lights)
+        {
+            render_context->m_LightBufferSubmitted.SetCapacity(max_lights);
+        }
+        render_context->m_LightBufferSubmitted.SetSize(max_lights);
+        memset(render_context->m_LightBufferSubmitted.Begin(), 0, max_lights);
     }
 
     void FinalizeLightData(HRenderContext render_context)

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -237,14 +237,6 @@ namespace dmRender
         render_context->m_RenderListSortIndices.SetSize(0);
         render_context->m_RenderListDispatch.SetSize(0);
         render_context->m_RenderListRanges.SetSize(0);
-
-        // Light instances retain their latest data between frames, but only lights
-        // submitted while building this frame's render list are included in LightBuffer.
-        if (!render_context->m_LightBufferSubmitted.Empty())
-        {
-            memset(render_context->m_LightBufferSubmitted.Begin(), 0, render_context->m_LightBufferSubmitted.Size());
-        }
-        render_context->m_LightBufferDirtyInfo = 1;
     }
 
     HNamedConstantBuffer PushRenderConstants(HRenderContext render_context, HNamedConstantBuffer constant_buffer)
@@ -409,10 +401,18 @@ namespace dmRender
         UpdateRenderContextMatrices(render_context, render_context->m_View, projection);
     }
 
-    void SetFrameTime(HRenderContext render_context, float time, float dt)
+    void BeginFrame(HRenderContext render_context, float time, float dt)
     {
         render_context->m_Time = time;
         render_context->m_Dt = dt;
+
+        // A frame may contain several render lists, so reset light submissions at
+        // the frame boundary and preserve them across all lists in the frame.
+        if (!render_context->m_LightBufferSubmitted.Empty())
+        {
+            memset(render_context->m_LightBufferSubmitted.Begin(), 0, render_context->m_LightBufferSubmitted.Size());
+        }
+        render_context->m_LightBufferDirtyInfo = 1;
     }
 
     Result AddToRender(HRenderContext context, RenderObject* ro)

--- a/engine/render/src/render/render.cpp
+++ b/engine/render/src/render/render.cpp
@@ -237,6 +237,14 @@ namespace dmRender
         render_context->m_RenderListSortIndices.SetSize(0);
         render_context->m_RenderListDispatch.SetSize(0);
         render_context->m_RenderListRanges.SetSize(0);
+
+        // Light instances retain their latest data between frames, but only lights
+        // submitted while building this frame's render list are included in LightBuffer.
+        if (!render_context->m_LightBufferSubmitted.Empty())
+        {
+            memset(render_context->m_LightBufferSubmitted.Begin(), 0, render_context->m_LightBufferSubmitted.Size());
+        }
+        render_context->m_LightBufferDirtyInfo = 1;
     }
 
     HNamedConstantBuffer PushRenderConstants(HRenderContext render_context, HNamedConstantBuffer constant_buffer)

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -252,8 +252,9 @@ namespace dmRender
     void SetViewMatrix(HRenderContext render_context, const dmVMath::Matrix4& view);
     void SetProjectionMatrix(HRenderContext render_context, const dmVMath::Matrix4& projection);
 
-    // Set current frame time and delta-time (in seconds) used for built-in material constants.
-    void SetFrameTime(HRenderContext render_context, float time, float dt);
+    // Begin a render frame by setting its time and delta-time (in seconds) and resetting
+    // per-frame renderer state such as submitted light instances.
+    void BeginFrame(HRenderContext render_context, float time, float dt);
 
     HMaterial GetContextMaterial(HRenderContext render_context);
 

--- a/engine/render/src/render/render.h
+++ b/engine/render/src/render/render.h
@@ -493,6 +493,8 @@ namespace dmRender
      * and is the basis for what's being written into the light buffer. It has a position and a rotation (direction),
      * and in the future it is likely that a light instance can override certain parameters of the light prototype.
      * A light prototype can be used across many light instances, and must live as long as the lights live.
+     * Instance data persists between frames; SubmitLightInstance selects which instances participate in the
+     * current frame's light buffer.
      */
     HLightPrototype NewLightPrototype(HRenderContext render_context, const LightPrototypeParams& params);
     void            SetLightPrototype(HRenderContext render_context, HLightPrototype light_prototype, const LightPrototypeParams& params);
@@ -503,7 +505,7 @@ namespace dmRender
     HLightInstance  NewLightInstance(HRenderContext render_context, HLightPrototype light_prototype);
     void            DeleteLightInstance(HRenderContext render_context, HLightInstance light_instance);
     void            SetLightInstance(HRenderContext render_context, HLightInstance light_instance, dmVMath::Point3 position, dmVMath::Quat rotation, float scale);
-    void            SetAmbientLight(HRenderContext render_context, dmVMath::Vector3 color);
+    void            SubmitLightInstance(HRenderContext render_context, HLightInstance light_instance);
     void            SetLightBufferCount(HRenderContext render_context, uint32_t max_lights);
 
     static inline dmGraphics::TextureWrap WrapFromDDF(dmRenderDDF::MaterialDesc::WrapMode wrap_mode)

--- a/engine/render/src/render/render_private.h
+++ b/engine/render/src/render/render_private.h
@@ -335,6 +335,7 @@ namespace dmRender
 
         dmArray<LightSTD140>                   m_LightBufferScratch;
         dmArray<LightSTD140>                   m_LightBufferUploadScratch;
+        dmArray<uint8_t>                       m_LightBufferSubmitted;
         dmGraphics::HUniformBuffer             m_LightUniformBuffer;
         dmVMath::Vector3                       m_AmbientLight;
 

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -3226,6 +3226,17 @@ TEST_F(dmRenderTest, LightBufferTestAllTypes)
 {
     dmRender::LightPrototypeParams params;
 
+    params.m_Type = dmRender::LIGHT_TYPE_AMBIENT;
+    params.m_Color = dmVMath::Vector4(0.25f, 0.5f, 0.75f, 1.0f);
+    params.m_Intensity = 2.0f;
+    dmRender::HLightPrototype proto_ambient = dmRender::NewLightPrototype(m_Context, params);
+    ASSERT_NE((dmRender::HLightPrototype)0, proto_ambient);
+    dmRender::HLightInstance inst_ambient = dmRender::NewLightInstance(m_Context, proto_ambient);
+    ASSERT_NE((dmRender::HLightInstance)0, inst_ambient);
+    dmRender::SetLightInstance(m_Context, inst_ambient, dmVMath::Point3(0, 0, 0), dmVMath::Quat::identity(), 1.0f);
+    dmRender::DeleteLightInstance(m_Context, inst_ambient);
+    dmRender::DeleteLightPrototype(m_Context, proto_ambient);
+
     params.m_Type = dmRender::LIGHT_TYPE_DIRECTIONAL;
     params.m_Color = dmVMath::Vector4(1.0f, 0.0f, 0.0f, 1.0f);
     params.m_Intensity = 2.0f;
@@ -3261,6 +3272,27 @@ TEST_F(dmRenderTest, LightBufferTestAllTypes)
     dmRender::SetLightInstance(m_Context, inst_spot, dmVMath::Point3(0, 0, 10), dmVMath::Quat::identity(), 1.0f);
     dmRender::DeleteLightInstance(m_Context, inst_spot);
     dmRender::DeleteLightPrototype(m_Context, proto_spot);
+}
+
+TEST_F(dmRenderTest, LightBufferSubmissionIsPerFrame)
+{
+    dmRender::LightPrototypeParams params;
+    dmRender::HLightPrototype prototype = dmRender::NewLightPrototype(m_Context, params);
+    dmRender::HLightInstance instance = dmRender::NewLightInstance(m_Context, prototype);
+    ASSERT_NE((dmRender::HLightInstance)0, instance);
+
+    uint16_t light_buffer_index = instance & 0xFFFF;
+    dmRender::RenderContext* render_context = (dmRender::RenderContext*) m_Context;
+
+    dmRender::RenderListBegin(m_Context);
+    dmRender::SubmitLightInstance(m_Context, instance);
+    ASSERT_EQ(1, render_context->m_LightBufferSubmitted[light_buffer_index]);
+
+    dmRender::RenderListBegin(m_Context);
+    ASSERT_EQ(0, render_context->m_LightBufferSubmitted[light_buffer_index]);
+
+    dmRender::DeleteLightInstance(m_Context, instance);
+    dmRender::DeleteLightPrototype(m_Context, prototype);
 }
 
 TEST_F(dmRenderTest, LightBufferTestMultipleInstances)

--- a/engine/render/src/test/test_render.cpp
+++ b/engine/render/src/test/test_render.cpp
@@ -3284,11 +3284,16 @@ TEST_F(dmRenderTest, LightBufferSubmissionIsPerFrame)
     uint16_t light_buffer_index = instance & 0xFFFF;
     dmRender::RenderContext* render_context = (dmRender::RenderContext*) m_Context;
 
+    dmRender::BeginFrame(m_Context, 1.0f, 1.0f / 60.0f);
     dmRender::RenderListBegin(m_Context);
     dmRender::SubmitLightInstance(m_Context, instance);
     ASSERT_EQ(1, render_context->m_LightBufferSubmitted[light_buffer_index]);
 
+    // Starting another render list in the same frame must preserve submissions.
     dmRender::RenderListBegin(m_Context);
+    ASSERT_EQ(1, render_context->m_LightBufferSubmitted[light_buffer_index]);
+
+    dmRender::BeginFrame(m_Context, 2.0f, 1.0f / 60.0f);
     ASSERT_EQ(0, render_context->m_LightBufferSubmitted[light_buffer_index]);
 
     dmRender::DeleteLightInstance(m_Context, instance);
@@ -3458,10 +3463,10 @@ TEST_F(dmRenderTest, ConstantTypeTimeSetsTimeAndDt)
     dmGraphics::ProgramResourceBinding& pgm_res = null_program->m_BaseProgram.m_ResourceBindings[set][binding];
     uint32_t uniform_offset = pgm_res.m_UniformBufferOffset + buffer_offset;
 
-    // Set frame time values on the render context.
+    // Begin the frame with time values on the render context.
     float time = 123.0f;
     float dt   = 1.0f / 60.0f;
-    dmRender::SetFrameTime(m_Context, time, dt);
+    dmRender::BeginFrame(m_Context, time, dt);
 
     // Enable the program so constants can be written to its uniform buffer.
     dmGraphics::EnableProgram(m_GraphicsContext, program);


### PR DESCRIPTION
Fixed an issue where the ambient light contribution from multiple collections were overwritten at random from secondary collections. 

Fixes #13004