### PR TITLE
Support wildcards in .defignore and .defunload patterns

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -547,6 +547,43 @@ public class ProjectBuildTest {
     }
 
     @Test
+    public void testFindResourcePathsRespectsDefignoreWildcards() throws IOException {
+        createFile(contentRoot, ".defignore", "/levels/*/tiled\n/a.b\n");
+        createFile(contentRoot, "levels/1/tiled/x.txt", "");
+        createFile(contentRoot, "levels/1/other.txt", "");
+        createFile(contentRoot, "levels/tiled/y.txt", "");
+        createFile(contentRoot, "levelsX/1/tiled/z.txt", "");
+        createFile(contentRoot, "aXb/k.txt", "");
+        createFile(contentRoot, "a.b/m.txt", "");
+
+        try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
+            List<String> paths = new ArrayList<>();
+            project.findResourcePaths("", paths);
+            assertEquals(new HashSet<>(Arrays.asList(
+                    ".defignore",
+                    "game.project",
+                    "test.png",
+                    "levels/1/other.txt",
+                    "levels/tiled/y.txt",
+                    "levelsX/1/tiled/z.txt",
+                    "aXb/k.txt")),
+                    new HashSet<>(paths));
+
+            List<String> ignoredPaths = new ArrayList<>();
+            project.findResourcePaths("levels/1/tiled", ignoredPaths);
+            assertTrue(ignoredPaths.isEmpty());
+
+            List<String> dirs = new ArrayList<>();
+            project.findResourceDirs("levels/1", dirs);
+            assertTrue(dirs.isEmpty());
+
+            List<String> levelDirs = new ArrayList<>();
+            project.findResourceDirs("levels", levelDirs);
+            assertEquals(new HashSet<>(Arrays.asList("1", "tiled")), new HashSet<>(levelDirs));
+        }
+    }
+
+    @Test
     public void testGameProjectMetaProperties() throws IOException, ConfigurationException, CompileExceptionError, MultipleCompileException, ParseException {
         projectName = "String Array";
         createDefaultFiles();

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/ProjectBuildTest.java
@@ -548,13 +548,28 @@ public class ProjectBuildTest {
 
     @Test
     public void testFindResourcePathsRespectsDefignoreWildcards() throws IOException {
-        createFile(contentRoot, ".defignore", "/levels/*/tiled\n/a.b\n");
+        createFile(contentRoot, ".defignore", """
+                /levels/*/tiled
+                /a.b/*
+                /dir(1)/*.png
+                /**/generated
+                /Upper/*
+                /lower_lit
+                """);
         createFile(contentRoot, "levels/1/tiled/x.txt", "");
         createFile(contentRoot, "levels/1/other.txt", "");
         createFile(contentRoot, "levels/tiled/y.txt", "");
         createFile(contentRoot, "levelsX/1/tiled/z.txt", "");
-        createFile(contentRoot, "aXb/k.txt", "");
         createFile(contentRoot, "a.b/m.txt", "");
+        createFile(contentRoot, "aXb/k.txt", "");
+        createFile(contentRoot, "dir(1)/a.png", "");
+        createFile(contentRoot, "dir(1)/b.txt", "");
+        createFile(contentRoot, "dir1/c.png", "");
+        createFile(contentRoot, "generated/root.txt", "");
+        createFile(contentRoot, "deep/nested/generated/n.txt", "");
+        createFile(contentRoot, "deep/nested/ungenerated/u.txt", "");
+        createFile(contentRoot, "upper/v.txt", "");
+        createFile(contentRoot, "Lower_lit/w.txt", "");
 
         try (Project project = new Project(new DefaultFileSystem(), contentRoot, "build")) {
             List<String> paths = new ArrayList<>();
@@ -566,7 +581,12 @@ public class ProjectBuildTest {
                     "levels/1/other.txt",
                     "levels/tiled/y.txt",
                     "levelsX/1/tiled/z.txt",
-                    "aXb/k.txt")),
+                    "aXb/k.txt",
+                    "dir(1)/b.txt",
+                    "dir1/c.png",
+                    "deep/nested/ungenerated/u.txt",
+                    "upper/v.txt",
+                    "Lower_lit/w.txt")),
                     new HashSet<>(paths));
 
             List<String> ignoredPaths = new ArrayList<>();
@@ -580,6 +600,10 @@ public class ProjectBuildTest {
             List<String> levelDirs = new ArrayList<>();
             project.findResourceDirs("levels", levelDirs);
             assertEquals(new HashSet<>(Arrays.asList("1", "tiled")), new HashSet<>(levelDirs));
+
+            List<String> nestedDirs = new ArrayList<>();
+            project.findResourceDirs("deep/nested", nestedDirs);
+            assertEquals(new HashSet<>(Arrays.asList("ungenerated")), new HashSet<>(nestedDirs));
         }
     }
 

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/PathUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/util/PathUtilTest.java
@@ -17,6 +17,10 @@ package com.dynamo.bob.test.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Predicate;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,5 +88,108 @@ public class PathUtilTest {
         assertFalse(match("a/a.txt", pattern));
         assertTrue(match("a/a/a.txt", pattern));
     }
-}
 
+    private static Predicate<String> projPathPredicate(String... patterns) {
+        return PathUtil.makeProjPathPredicate(Arrays.asList(patterns));
+    }
+
+    @Test
+    public void testProjPathPredicateEmpty() {
+        Predicate<String> pred = PathUtil.makeProjPathPredicate(Collections.emptyList());
+        assertFalse(pred.test("/a"));
+        assertFalse(pred.test("/a/b.txt"));
+    }
+
+    @Test
+    public void testProjPathPredicateLiteral() {
+        Predicate<String> pred = projPathPredicate("/a", "/b.c");
+        assertTrue(pred.test("/a"));
+        assertTrue(pred.test("/a/b"));
+        assertTrue(pred.test("/a/b/c.txt"));
+        assertFalse(pred.test("/ab"));
+        assertFalse(pred.test("/aba"));
+        assertFalse(pred.test("/ab/a"));
+        assertTrue(pred.test("/b.c"));
+        assertTrue(pred.test("/b.c/d"));
+        assertFalse(pred.test("/bXc"));
+    }
+
+    @Test
+    public void testProjPathPredicateWildcards() {
+        Predicate<String> pred = projPathPredicate("/levels/*/tiled");
+        assertTrue(pred.test("/levels/1/tiled"));
+        assertTrue(pred.test("/levels/1/tiled/a.txt"));
+        assertFalse(pred.test("/levels"));
+        assertFalse(pred.test("/levels/1"));
+        assertFalse(pred.test("/levels/tiled"));
+        assertFalse(pred.test("/levelsX/1/tiled"));
+        assertFalse(pred.test("/levels/1/tiledX"));
+        assertFalse(pred.test("/levels/1/other.txt"));
+
+        pred = projPathPredicate("/levels/*");
+        assertTrue(pred.test("/levels/a.txt"));
+        assertTrue(pred.test("/levels/a/b.txt"));
+        assertFalse(pred.test("/levels"));
+
+        pred = projPathPredicate("/a?c");
+        assertTrue(pred.test("/abc"));
+        assertFalse(pred.test("/ac"));
+        assertFalse(pred.test("/a/c"));
+
+        pred = projPathPredicate("/levels/**");
+        assertTrue(pred.test("/levels"));
+        assertTrue(pred.test("/levels/a/b/c.txt"));
+        assertFalse(pred.test("/levelsX"));
+
+        pred = projPathPredicate("/**/tiled");
+        assertTrue(pred.test("/tiled"));
+        assertTrue(pred.test("/a/tiled"));
+        assertTrue(pred.test("/a/b/tiled/c.txt"));
+        assertFalse(pred.test("/a/b/untiled"));
+
+        pred = projPathPredicate("/a/**/b");
+        assertTrue(pred.test("/a/b"));
+        assertTrue(pred.test("/a/x/y/b"));
+        assertFalse(pred.test("/a/xb"));
+
+        pred = projPathPredicate("/a**b");
+        assertTrue(pred.test("/ab"));
+        assertTrue(pred.test("/a/x/b"));
+        assertFalse(pred.test("/a/x/c"));
+    }
+
+    @Test
+    public void testProjPathPredicateRegexControlCharacters() {
+        Predicate<String> pred = projPathPredicate("/a.b/*", "/dir(1)/*.png", "/[x]/*", "/a+b/*", "/c$/*", "/d\\e/*", "/^f/*");
+        assertTrue(pred.test("/a.b/k.txt"));
+        assertFalse(pred.test("/aXb/k.txt"));
+        assertTrue(pred.test("/dir(1)/a.png"));
+        assertFalse(pred.test("/dir1/a.png"));
+        assertFalse(pred.test("/dir(1)/aXpng"));
+        assertTrue(pred.test("/[x]/k.txt"));
+        assertFalse(pred.test("/x/k.txt"));
+        assertTrue(pred.test("/a+b/k.txt"));
+        assertFalse(pred.test("/aab/k.txt"));
+        assertTrue(pred.test("/c$/k.txt"));
+        assertFalse(pred.test("/c/k.txt"));
+        assertTrue(pred.test("/d\\e/k.txt"));
+        assertFalse(pred.test("/de/k.txt"));
+        assertTrue(pred.test("/^f/k.txt"));
+        assertFalse(pred.test("/f/k.txt"));
+    }
+
+    @Test
+    public void testProjPathPredicateIsCaseSensitive() {
+        Predicate<String> pred = projPathPredicate("/Levels", "/Assets/*.png", "/**/Generated");
+        assertTrue(pred.test("/Levels"));
+        assertTrue(pred.test("/Levels/a.txt"));
+        assertFalse(pred.test("/levels"));
+        assertFalse(pred.test("/levels/a.txt"));
+        assertFalse(pred.test("/LEVELS"));
+        assertTrue(pred.test("/Assets/a.png"));
+        assertFalse(pred.test("/assets/a.png"));
+        assertFalse(pred.test("/Assets/a.PNG"));
+        assertTrue(pred.test("/a/Generated/b.txt"));
+        assertFalse(pred.test("/a/generated/b.txt"));
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -30,6 +30,7 @@ import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.fs.FileSystemWalker;
 import com.dynamo.bob.fs.IFileSystem;
 import com.dynamo.bob.fs.IResource;
+import com.dynamo.bob.util.PathUtil;
 import com.dynamo.bob.util.TimeProfiler;
 
 // Owns project-local resource walking, ignore rules, and the cached resource path list.
@@ -39,7 +40,7 @@ class ProjectResourceWalker {
     private final IFileSystem fileSystem;
     private List<String> allResourcePathsCache; // Cache for all resource paths, since Bob doesn't change project files during build
     private List<String> ignoredResourcePathPatterns;
-    private List<Pattern> ignoredResourcePathGlobs;
+    private Predicate<String> ignoredResourcePathPredicate;
 
     ProjectResourceWalker(Project project, IFileSystem fileSystem) {
         this.project = project;
@@ -49,7 +50,7 @@ class ProjectResourceWalker {
     public void clearCaches() {
         allResourcePathsCache = null;
         ignoredResourcePathPatterns = null;
-        ignoredResourcePathGlobs = null;
+        ignoredResourcePathPredicate = null;
     }
 
     public void initIgnorePatterns() throws CompileExceptionError {
@@ -144,17 +145,8 @@ class ProjectResourceWalker {
         }, results);
     }
 
-    /*
-        The same `.defignore` matching logic is implemented in the Editor.
-        If you change something here, make sure you change it in resource.clj
-        (make-proj-path-patterns-pred-raw).
-
-        A pattern matches a path if it equals the path or is a directory prefix
-        of it. Patterns may contain wildcards: `*` matches any run of non-slash
-        characters, `**` matches across slashes and `?` matches a single
-        non-slash character. Everything else is literal. Note that `**` does
-        not absorb adjacent slashes, so `/a/**` does not match `/a` itself.
-    */
+    // Returns the `.defignore` patterns as project paths. The matching rules
+    // live in PathUtil.makeProjPathPredicate, which the editor uses as well.
     private List<String> loadIgnoredResourcePathPatterns() throws CompileExceptionError {
         if (ignoredResourcePathPatterns != null) {
             return ignoredResourcePathPatterns;
@@ -186,58 +178,18 @@ class ProjectResourceWalker {
             }
         }
 
-        ignoredResourcePathPatterns = new ArrayList<>();
-        ignoredResourcePathGlobs = new ArrayList<>();
-        for (String pattern : patterns) {
-            if (isGlobPattern(pattern)) {
-                ignoredResourcePathGlobs.add(globToRegex(pattern));
-            } else {
-                ignoredResourcePathPatterns.add(pattern);
-            }
-        }
+        ignoredResourcePathPatterns = new ArrayList<>(patterns);
+        ignoredResourcePathPredicate = PathUtil.makeProjPathPredicate(ignoredResourcePathPatterns);
         return ignoredResourcePathPatterns;
     }
 
-    private static boolean isGlobPattern(String pattern) {
-        return pattern.indexOf('*') >= 0 || pattern.indexOf('?') >= 0;
-    }
-
-    private static Pattern globToRegex(String glob) {
-        StringBuilder regex = new StringBuilder("^");
-        StringBuilder literal = new StringBuilder();
-        int n = glob.length();
-        for (int i = 0; i < n; ++i) {
-            char c = glob.charAt(i);
-            if (c == '*' || c == '?') {
-                if (literal.length() > 0) {
-                    regex.append(Pattern.quote(literal.toString()));
-                    literal.setLength(0);
-                }
-                if (c == '?') {
-                    regex.append("[^/]");
-                } else if (i + 1 < n && glob.charAt(i + 1) == '*') {
-                    regex.append(".*");
-                    ++i;
-                } else {
-                    regex.append("[^/]*");
-                }
-            } else {
-                literal.append(c);
-            }
-        }
-        if (literal.length() > 0) {
-            regex.append(Pattern.quote(literal.toString()));
-        }
-        regex.append("(/.*)?$");
-        return Pattern.compile(regex.toString());
-    }
-
-    private List<String> getIgnoredResourcePathPatterns() {
+    private Predicate<String> getIgnoredResourcePathPredicate() {
         try {
-            return loadIgnoredResourcePathPatterns();
+            loadIgnoredResourcePathPatterns();
         } catch (CompileExceptionError e) {
             throw new RuntimeException(e);
         }
+        return ignoredResourcePathPredicate;
     }
 
     private boolean isIgnoredResourcePath(String path) {
@@ -246,24 +198,12 @@ class ProjectResourceWalker {
             return false;
         }
 
-        for (String ignoredPathPattern : getIgnoredResourcePathPatterns()) {
-            if (normalizedPath.equals(ignoredPathPattern) || normalizedPath.startsWith(ignoredPathPattern + "/")) {
-                return true;
-            }
-        }
-
-        for (Pattern glob : ignoredResourcePathGlobs) {
-            if (glob.matcher(normalizedPath).matches()) {
-                return true;
-            }
-        }
-
-        return false;
+        return getIgnoredResourcePathPredicate().test("/" + normalizedPath);
     }
 
     private static String normalizeIgnoredPathPattern(String path) {
-        path = FilenameUtils.separatorsToUnix(path);
-        return Project.stripLeadingAndTrailingSlashes(path);
+        path = Project.stripLeadingAndTrailingSlashes(FilenameUtils.separatorsToUnix(path));
+        return path.isEmpty() ? path : "/" + path;
     }
 
     private static String normalizeResourcePathForMatching(String path) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProjectResourceWalker.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -38,6 +39,7 @@ class ProjectResourceWalker {
     private final IFileSystem fileSystem;
     private List<String> allResourcePathsCache; // Cache for all resource paths, since Bob doesn't change project files during build
     private List<String> ignoredResourcePathPatterns;
+    private List<Pattern> ignoredResourcePathGlobs;
 
     ProjectResourceWalker(Project project, IFileSystem fileSystem) {
         this.project = project;
@@ -47,6 +49,7 @@ class ProjectResourceWalker {
     public void clearCaches() {
         allResourcePathsCache = null;
         ignoredResourcePathPatterns = null;
+        ignoredResourcePathGlobs = null;
     }
 
     public void initIgnorePatterns() throws CompileExceptionError {
@@ -144,7 +147,13 @@ class ProjectResourceWalker {
     /*
         The same `.defignore` matching logic is implemented in the Editor.
         If you change something here, make sure you change it in resource.clj
-        (defignore-pred).
+        (make-proj-path-patterns-pred-raw).
+
+        A pattern matches a path if it equals the path or is a directory prefix
+        of it. Patterns may contain wildcards: `*` matches any run of non-slash
+        characters, `**` matches across slashes and `?` matches a single
+        non-slash character. Everything else is literal. Note that `**` does
+        not absorb adjacent slashes, so `/a/**` does not match `/a` itself.
     */
     private List<String> loadIgnoredResourcePathPatterns() throws CompileExceptionError {
         if (ignoredResourcePathPatterns != null) {
@@ -177,8 +186,50 @@ class ProjectResourceWalker {
             }
         }
 
-        ignoredResourcePathPatterns = new ArrayList<>(patterns);
+        ignoredResourcePathPatterns = new ArrayList<>();
+        ignoredResourcePathGlobs = new ArrayList<>();
+        for (String pattern : patterns) {
+            if (isGlobPattern(pattern)) {
+                ignoredResourcePathGlobs.add(globToRegex(pattern));
+            } else {
+                ignoredResourcePathPatterns.add(pattern);
+            }
+        }
         return ignoredResourcePathPatterns;
+    }
+
+    private static boolean isGlobPattern(String pattern) {
+        return pattern.indexOf('*') >= 0 || pattern.indexOf('?') >= 0;
+    }
+
+    private static Pattern globToRegex(String glob) {
+        StringBuilder regex = new StringBuilder("^");
+        StringBuilder literal = new StringBuilder();
+        int n = glob.length();
+        for (int i = 0; i < n; ++i) {
+            char c = glob.charAt(i);
+            if (c == '*' || c == '?') {
+                if (literal.length() > 0) {
+                    regex.append(Pattern.quote(literal.toString()));
+                    literal.setLength(0);
+                }
+                if (c == '?') {
+                    regex.append("[^/]");
+                } else if (i + 1 < n && glob.charAt(i + 1) == '*') {
+                    regex.append(".*");
+                    ++i;
+                } else {
+                    regex.append("[^/]*");
+                }
+            } else {
+                literal.append(c);
+            }
+        }
+        if (literal.length() > 0) {
+            regex.append(Pattern.quote(literal.toString()));
+        }
+        regex.append("(/.*)?$");
+        return Pattern.compile(regex.toString());
     }
 
     private List<String> getIgnoredResourcePathPatterns() {
@@ -197,6 +248,12 @@ class ProjectResourceWalker {
 
         for (String ignoredPathPattern : getIgnoredResourcePathPatterns()) {
             if (normalizedPath.equals(ignoredPathPattern) || normalizedPath.startsWith(ignoredPathPattern + "/")) {
+                return true;
+            }
+        }
+
+        for (Pattern glob : ignoredResourcePathGlobs) {
+            if (glob.matcher(normalizedPath).matches()) {
                 return true;
             }
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PathUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/PathUtil.java
@@ -14,6 +14,9 @@
 
 package com.dynamo.bob.util;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
@@ -62,5 +65,85 @@ public class PathUtil {
             pattern = pattern.substring(offset);
         }
         return Pattern.matches(regex.toString(), path);
+    }
+
+    /**
+     * Creates a predicate that tests project paths against a list of patterns
+     * of the kind found in `.defignore` and `.defunload` files. Shared between
+     * Bob and the editor, so the two always agree on what a pattern matches.
+     *
+     * Both patterns and tested paths are project paths: they start with `/`
+     * and have no trailing `/`. Matching is exact and case-sensitive regardless
+     * of the file system. A pattern matches a path if it matches the whole path
+     * or one of its parent directories, so `/dir` matches `/dir` and
+     * `/dir/entry` but not `/dire`.
+     *
+     * Patterns may contain wildcards:
+     * 1) * matches zero or more characters except /
+     * 2) ? matches exactly one character except /
+     * 3) **&#47; matches zero or more whole path segments
+     * 4) a trailing /** matches the directory itself and everything below it
+     * Everything else is matched literally.
+     */
+    public static Predicate<String> makeProjPathPredicate(Iterable<String> patterns) {
+        List<String> literals = new ArrayList<>();
+        List<Pattern> globs = new ArrayList<>();
+        for (String pattern : patterns) {
+            if (pattern.indexOf('*') >= 0 || pattern.indexOf('?') >= 0) {
+                globs.add(projPathGlobToRegex(pattern));
+            } else {
+                literals.add(pattern);
+            }
+        }
+        return projPath -> {
+            for (String literal : literals) {
+                if (projPath.startsWith(literal)
+                        && (projPath.length() == literal.length() || projPath.charAt(literal.length()) == '/')) {
+                    return true;
+                }
+            }
+            for (Pattern glob : globs) {
+                if (glob.matcher(projPath).matches()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    private static Pattern projPathGlobToRegex(String glob) {
+        if (glob.endsWith("/**")) {
+            glob = glob.substring(0, glob.length() - 3);
+        }
+        StringBuilder regex = new StringBuilder("^");
+        StringBuilder literal = new StringBuilder();
+        int n = glob.length();
+        for (int i = 0; i < n; ++i) {
+            char c = glob.charAt(i);
+            if (c != '*' && c != '?') {
+                literal.append(c);
+                continue;
+            }
+            if (literal.length() > 0) {
+                regex.append(Pattern.quote(literal.toString()));
+                literal.setLength(0);
+            }
+            if (c == '?') {
+                regex.append("[^/]");
+            } else if (glob.startsWith("**/", i)) {
+                regex.append("(?:.*/)?");
+                i += 2;
+            } else if (glob.startsWith("**", i)) {
+                regex.append(".*");
+                i += 1;
+            } else {
+                regex.append("[^/]*");
+            }
+        }
+        if (literal.length() > 0) {
+            regex.append(Pattern.quote(literal.toString()));
+        }
+        regex.append("(?:/.*)?$");
+        return Pattern.compile(regex.toString());
     }
 }

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -33,10 +33,10 @@
             [util.text-util :as text-util])
   (:import [clojure.lang PersistentHashMap]
            [com.defold.editor Editor]
+           [com.dynamo.bob.util PathUtil]
            [java.io Closeable File FilterInputStream IOException InputStream]
            [java.net URI]
            [java.nio.file FileSystem FileSystems]
-           [java.util.regex Pattern]
            [java.util.zip ZipEntry ZipFile]
            [org.apache.commons.io FilenameUtils IOUtils]))
 
@@ -348,73 +348,20 @@
        (make-defignore-patterns-key)
        (make-defignore-patterns project-directory)))
 
-(defn- glob-pattern? [^String pattern]
-  (or (string/includes? pattern "*")
-      (string/includes? pattern "?")))
-
-(defn- glob->regex
-  ^Pattern [^String glob]
-  (let [regex (StringBuilder. "^")
-        literal (StringBuilder.)
-        length (.length glob)
-        flush-literal! (fn flush-literal! []
-                         (when (pos? (.length literal))
-                           (.append regex (Pattern/quote (.toString literal)))
-                           (.setLength literal 0)))]
-    (loop [i 0]
-      (when (< i length)
-        (let [c (.charAt glob i)]
-          (case c
-            \? (do (flush-literal!)
-                   (.append regex "[^/]")
-                   (recur (inc i)))
-            \* (do (flush-literal!)
-                   (if (and (< (inc i) length)
-                            (= \* (.charAt glob (inc i))))
-                     (do (.append regex ".*")
-                         (recur (+ i 2)))
-                     (do (.append regex "[^/]*")
-                         (recur (inc i)))))
-            (do (.append literal c)
-                (recur (inc i)))))))
-    (flush-literal!)
-    (.append regex "(/.*)?$")
-    (Pattern/compile (.toString regex))))
-
 (defn make-proj-path-patterns-pred-raw
   "Returns a predicate that takes a proj-path and returns true if it starts with
   or matches one of the listed proj-path-patterns. Patterns may contain
-  wildcards: `*` matches any run of non-slash characters, `**` matches across
-  slashes and `?` matches a single non-slash character. Note that `**` does not
-  absorb adjacent slashes, so `/a/**` does not match `/a` itself.
-
-  The same matching logic is implemented in Bob. If you change something here,
-  make sure you change it in ProjectResourceWalker.java as well."
+  wildcards. The matching rules are shared with Bob, see
+  PathUtil.makeProjPathPredicate."
   [proj-path-patterns]
   {:pre [(or (nil? proj-path-patterns)
              (s/assert ::proj-path-patterns proj-path-patterns))]
    :post [(s/assert ::proj-path-pred %)]}
   (if (zero? (count proj-path-patterns))
     fn/constantly-false
-    (let [{literal-patterns false glob-patterns true} (group-by glob-pattern? proj-path-patterns)
-          regexes (mapv glob->regex glob-patterns)]
+    (let [pred (PathUtil/makeProjPathPredicate proj-path-patterns)]
       (fn matched-proj-path? [^String proj-path]
-        (let [proj-path-length (.length proj-path)]
-          (boolean
-            (or
-              (coll/some
-                (fn [^String pattern]
-                  ;; Make sure a "/dir" pattern matches "/dir" and "/dir/entry",
-                  ;; but not "/dire".
-                  (and (string/starts-with? proj-path pattern)
-                       (let [pattern-length (.length pattern)]
-                         (or (= pattern-length proj-path-length)
-                             (= \/ (.charAt proj-path pattern-length))))))
-                literal-patterns)
-              (coll/some
-                (fn [^Pattern regex]
-                  (.matches (.matcher regex proj-path)))
-                regexes))))))))
+        (.test pred proj-path)))))
 
 (def ^:private make-proj-path-patterns-pred-fn
   (fn/memoize

--- a/editor/src/clj/editor/resource.clj
+++ b/editor/src/clj/editor/resource.clj
@@ -36,6 +36,7 @@
            [java.io Closeable File FilterInputStream IOException InputStream]
            [java.net URI]
            [java.nio.file FileSystem FileSystems]
+           [java.util.regex Pattern]
            [java.util.zip ZipEntry ZipFile]
            [org.apache.commons.io FilenameUtils IOUtils]))
 
@@ -347,27 +348,73 @@
        (make-defignore-patterns-key)
        (make-defignore-patterns project-directory)))
 
+(defn- glob-pattern? [^String pattern]
+  (or (string/includes? pattern "*")
+      (string/includes? pattern "?")))
+
+(defn- glob->regex
+  ^Pattern [^String glob]
+  (let [regex (StringBuilder. "^")
+        literal (StringBuilder.)
+        length (.length glob)
+        flush-literal! (fn flush-literal! []
+                         (when (pos? (.length literal))
+                           (.append regex (Pattern/quote (.toString literal)))
+                           (.setLength literal 0)))]
+    (loop [i 0]
+      (when (< i length)
+        (let [c (.charAt glob i)]
+          (case c
+            \? (do (flush-literal!)
+                   (.append regex "[^/]")
+                   (recur (inc i)))
+            \* (do (flush-literal!)
+                   (if (and (< (inc i) length)
+                            (= \* (.charAt glob (inc i))))
+                     (do (.append regex ".*")
+                         (recur (+ i 2)))
+                     (do (.append regex "[^/]*")
+                         (recur (inc i)))))
+            (do (.append literal c)
+                (recur (inc i)))))))
+    (flush-literal!)
+    (.append regex "(/.*)?$")
+    (Pattern/compile (.toString regex))))
+
 (defn make-proj-path-patterns-pred-raw
   "Returns a predicate that takes a proj-path and returns true if it starts with
-  or matches one of the listed proj-paths."
+  or matches one of the listed proj-path-patterns. Patterns may contain
+  wildcards: `*` matches any run of non-slash characters, `**` matches across
+  slashes and `?` matches a single non-slash character. Note that `**` does not
+  absorb adjacent slashes, so `/a/**` does not match `/a` itself.
+
+  The same matching logic is implemented in Bob. If you change something here,
+  make sure you change it in ProjectResourceWalker.java as well."
   [proj-path-patterns]
   {:pre [(or (nil? proj-path-patterns)
              (s/assert ::proj-path-patterns proj-path-patterns))]
    :post [(s/assert ::proj-path-pred %)]}
   (if (zero? (count proj-path-patterns))
     fn/constantly-false
-    (fn matched-proj-path? [^String proj-path]
-      (let [proj-path-length (.length proj-path)]
-        (boolean
-          (coll/some
-            (fn [^String pattern]
-              ;; Make sure a "/dir" pattern matches "/dir" and "/dir/entry",
-              ;; but not "/dire".
-              (and (string/starts-with? proj-path pattern)
-                   (let [pattern-length (.length pattern)]
-                     (or (= pattern-length proj-path-length)
-                         (= \/ (.charAt proj-path pattern-length))))))
-            proj-path-patterns))))))
+    (let [{literal-patterns false glob-patterns true} (group-by glob-pattern? proj-path-patterns)
+          regexes (mapv glob->regex glob-patterns)]
+      (fn matched-proj-path? [^String proj-path]
+        (let [proj-path-length (.length proj-path)]
+          (boolean
+            (or
+              (coll/some
+                (fn [^String pattern]
+                  ;; Make sure a "/dir" pattern matches "/dir" and "/dir/entry",
+                  ;; but not "/dire".
+                  (and (string/starts-with? proj-path pattern)
+                       (let [pattern-length (.length pattern)]
+                         (or (= pattern-length proj-path-length)
+                             (= \/ (.charAt proj-path pattern-length))))))
+                literal-patterns)
+              (coll/some
+                (fn [^Pattern regex]
+                  (.matches (.matcher regex proj-path)))
+                regexes))))))))
 
 (def ^:private make-proj-path-patterns-pred-fn
   (fn/memoize

--- a/editor/test/editor/resource_test.clj
+++ b/editor/test/editor/resource_test.clj
@@ -80,7 +80,39 @@
       (is (false? (proj-path-patterns-pred "/a/b")))
       (is (true? (proj-path-patterns-pred "/ab")))
       (is (false? (proj-path-patterns-pred "/aba")))
-      (is (true? (proj-path-patterns-pred "/ab/a"))))))
+      (is (true? (proj-path-patterns-pred "/ab/a")))))
+
+  (testing "Wildcard match rules."
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/levels/*/tiled"])]
+      (is (true? (proj-path-patterns-pred "/levels/1/tiled")))
+      (is (true? (proj-path-patterns-pred "/levels/1/tiled/a.txt")))
+      (is (false? (proj-path-patterns-pred "/levels")))
+      (is (false? (proj-path-patterns-pred "/levels/1")))
+      (is (false? (proj-path-patterns-pred "/levels/tiled")))
+      (is (false? (proj-path-patterns-pred "/levelsX/1/tiled")))
+      (is (false? (proj-path-patterns-pred "/levels/1/tiledX")))
+      (is (false? (proj-path-patterns-pred "/levels/1/other.txt"))))
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/levels/*"])]
+      (is (true? (proj-path-patterns-pred "/levels/a.txt")))
+      (is (true? (proj-path-patterns-pred "/levels/a/b.txt")))
+      (is (false? (proj-path-patterns-pred "/levels"))))
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/levels/**"])]
+      (is (true? (proj-path-patterns-pred "/levels/a/b/c.txt")))
+      (is (false? (proj-path-patterns-pred "/levels"))))
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/**/tiled"])]
+      (is (true? (proj-path-patterns-pred "/a/tiled")))
+      (is (true? (proj-path-patterns-pred "/a/b/tiled/c.txt")))
+      (is (false? (proj-path-patterns-pred "/tiled")))
+      (is (false? (proj-path-patterns-pred "/a/b/untiled"))))
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a?c"])]
+      (is (true? (proj-path-patterns-pred "/abc")))
+      (is (false? (proj-path-patterns-pred "/ac")))
+      (is (false? (proj-path-patterns-pred "/a/c"))))
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a.b" "/c.*"])]
+      (is (true? (proj-path-patterns-pred "/a.b")))
+      (is (false? (proj-path-patterns-pred "/aXb")))
+      (is (true? (proj-path-patterns-pred "/c.txt")))
+      (is (false? (proj-path-patterns-pred "/cXtxt"))))))
 
 (defn- set-file-lines! [file lines]
   (if (nil? lines)

--- a/editor/test/editor/resource_test.clj
+++ b/editor/test/editor/resource_test.clj
@@ -97,22 +97,49 @@
       (is (true? (proj-path-patterns-pred "/levels/a/b.txt")))
       (is (false? (proj-path-patterns-pred "/levels"))))
     (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/levels/**"])]
+      (is (true? (proj-path-patterns-pred "/levels")))
       (is (true? (proj-path-patterns-pred "/levels/a/b/c.txt")))
-      (is (false? (proj-path-patterns-pred "/levels"))))
+      (is (false? (proj-path-patterns-pred "/levelsX"))))
     (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/**/tiled"])]
+      (is (true? (proj-path-patterns-pred "/tiled")))
       (is (true? (proj-path-patterns-pred "/a/tiled")))
       (is (true? (proj-path-patterns-pred "/a/b/tiled/c.txt")))
-      (is (false? (proj-path-patterns-pred "/tiled")))
       (is (false? (proj-path-patterns-pred "/a/b/untiled"))))
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a/**/b"])]
+      (is (true? (proj-path-patterns-pred "/a/b")))
+      (is (true? (proj-path-patterns-pred "/a/x/y/b")))
+      (is (false? (proj-path-patterns-pred "/a/xb"))))
     (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a?c"])]
       (is (true? (proj-path-patterns-pred "/abc")))
       (is (false? (proj-path-patterns-pred "/ac")))
-      (is (false? (proj-path-patterns-pred "/a/c"))))
-    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a.b" "/c.*"])]
-      (is (true? (proj-path-patterns-pred "/a.b")))
-      (is (false? (proj-path-patterns-pred "/aXb")))
-      (is (true? (proj-path-patterns-pred "/c.txt")))
-      (is (false? (proj-path-patterns-pred "/cXtxt"))))))
+      (is (false? (proj-path-patterns-pred "/a/c")))))
+
+  (testing "Regex control characters are literal in wildcard patterns."
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/a.b/*" "/dir(1)/*.png" "/[x]/*" "/a+b/*" "/c$/*" "/d\\e/*"])]
+      (is (true? (proj-path-patterns-pred "/a.b/k.txt")))
+      (is (false? (proj-path-patterns-pred "/aXb/k.txt")))
+      (is (true? (proj-path-patterns-pred "/dir(1)/a.png")))
+      (is (false? (proj-path-patterns-pred "/dir1/a.png")))
+      (is (false? (proj-path-patterns-pred "/dir(1)/aXpng")))
+      (is (true? (proj-path-patterns-pred "/[x]/k.txt")))
+      (is (false? (proj-path-patterns-pred "/x/k.txt")))
+      (is (true? (proj-path-patterns-pred "/a+b/k.txt")))
+      (is (false? (proj-path-patterns-pred "/aab/k.txt")))
+      (is (true? (proj-path-patterns-pred "/c$/k.txt")))
+      (is (false? (proj-path-patterns-pred "/c/k.txt")))
+      (is (true? (proj-path-patterns-pred "/d\\e/k.txt")))
+      (is (false? (proj-path-patterns-pred "/de/k.txt")))))
+
+  (testing "Matching is case-sensitive for literal and wildcard patterns."
+    (let [proj-path-patterns-pred (resource/make-proj-path-patterns-pred-raw ["/Levels" "/Assets/*.png"])]
+      (is (true? (proj-path-patterns-pred "/Levels")))
+      (is (true? (proj-path-patterns-pred "/Levels/a.txt")))
+      (is (false? (proj-path-patterns-pred "/levels")))
+      (is (false? (proj-path-patterns-pred "/levels/a.txt")))
+      (is (false? (proj-path-patterns-pred "/LEVELS")))
+      (is (true? (proj-path-patterns-pred "/Assets/a.png")))
+      (is (false? (proj-path-patterns-pred "/assets/a.png")))
+      (is (false? (proj-path-patterns-pred "/Assets/a.PNG"))))))
 
 (defn- set-file-lines! [file lines]
   (if (nil? lines)


### PR DESCRIPTION
Now `.defignore` and `.defunload` files supports expressions with wildcard patterns.
Examples:
|Pattern|Matches|Does not match|
|-------|---------|----------------|
|/levels |/levels, /levels/1/map.tilemap|/levelsX, /Levels|
|/a.b|/a.b, /a.b/m.txt|/aXb|
|/levels/*/tiled|/levels/1/tiled, /levels/1/tiled/a.txt|/levels/tiled, /levels/1/tiledX, /levels/1/other.txt|
|/levels/*|/levels/a.txt, /levels/a/b.txt|/levels|
|/assets/temp_??.png|/assets/temp_01.png|/assets/temp_1.png, /assets/temp_001.png|
|/dir(1)/*.png|/dir(1)/a.png|/dir1/a.png, /dir(1)/b.txt|
|/**/generated|/generated, /a/b/generated/n.txt|/a/b/ungenerated|
|/levels/**|/levels, /levels/a/b/c.txt|/levelsX|
|/a/**/b|/a/b, /a/x/y/b|/a/xb|

Fixes #12853 
## PR checklist

* [x] Code
	* [x] Add engine and/or editor unit tests.
	* [x] New and changed code follows the overall code style of existing code
	* [x] Add comments where needed
* [x] Documentation
	* [x] Make sure that API documentation is updated in code comments
	* [x] Make sure that manuals are updated (in github.com/defold/doc)
* [x] Prepare pull request and affected issue for automatic release notes generator
	* [x] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [x] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [x] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [x] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [x] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [x] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```
