### PR TITLE
Fix editor atlas multiple image animation trim/pivot 

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/AtlasBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/AtlasBuilderTest.java
@@ -34,6 +34,7 @@ import com.dynamo.graphics.proto.Graphics.TextureImage;
 import com.dynamo.gamesys.proto.TextureSetProto.SpriteGeometry;
 import com.dynamo.gamesys.proto.TextureSetProto.TextureSet;
 import com.dynamo.gamesys.proto.TextureSetProto.TextureSetAnimation;
+import com.dynamo.gamesys.proto.Tile.SpriteTrimmingMode;
 import com.google.protobuf.Message;
 
 import com.dynamo.bob.util.MurmurHash;
@@ -309,6 +310,78 @@ public class AtlasBuilderTest extends AbstractProtoBuilderTest {
         imageNameHashes.add(MurmurHash.hash64("b/2"));
 
         assertEquals(imageNameHashes, textureSet.getImageNameHashesList());
+    }
+
+    // https://github.com/defold/defold/issues/13019
+    @Test
+    public void testAtlasImagePivotVariants() throws Exception {
+        addImage("/test_image.png", 16, 16);
+
+        StringBuilder src = new StringBuilder();
+        src.append("margin: 0\n");
+        src.append("extrude_borders: 0\n");
+        src.append("images: {");
+        src.append("  image: \"/test_image.png\"");
+        src.append("}");
+        src.append("animations: {");
+        src.append("  id: \"anim\"");
+        src.append("  images: {");
+        src.append("    image: \"/test_image.png\"");
+        src.append("    pivot_x: 0.0");
+        src.append("  }");
+        src.append("}");
+
+        List<Message> outputs = build("/test.atlas", src.toString());
+        TextureSet textureSet = (TextureSet)outputs.get(0);
+        assertNotNull(textureSet);
+
+        // One packed rect, so the atlas is the size of a single image.
+        assertThat(textureSet.getWidth(), is(16));
+        assertThat(textureSet.getHeight(), is(16));
+
+        // But a geometry each. SpriteGeometry stores the pivot relative to the image center with
+        // +Y up, so an authored 0.5 becomes 0.0 and an authored 0.0 becomes -0.5.
+        assertThat(textureSet.getGeometriesCount(), is(2));
+        assertEquals(-0.5f, textureSet.getGeometries(0).getPivotX(), 0.0001f);
+        assertEquals(0.0f, textureSet.getGeometries(1).getPivotX(), 0.0001f);
+
+        // Tile quads first, then "anim" and the standalone image, pointing at a geometry each.
+        assertEquals(Arrays.asList(0, 1, 0, 1), textureSet.getFrameIndicesList());
+    }
+
+    // https://github.com/defold/defold/issues/7403
+    @Test
+    public void testAtlasImageTrimModeVariants() throws Exception {
+        addImage("/test_image.png", 16, 16);
+
+        StringBuilder src = new StringBuilder();
+        src.append("margin: 0\n");
+        src.append("extrude_borders: 0\n");
+        src.append("images: {");
+        src.append("  image: \"/test_image.png\"");
+        src.append("}");
+        src.append("animations: {");
+        src.append("  id: \"anim\"");
+        src.append("  images: {");
+        src.append("    image: \"/test_image.png\"");
+        src.append("    sprite_trim_mode: SPRITE_TRIM_MODE_4");
+        src.append("  }");
+        src.append("}");
+
+        List<Message> outputs = build("/test.atlas", src.toString());
+        TextureSet textureSet = (TextureSet)outputs.get(0);
+        assertNotNull(textureSet);
+
+        // One packed rect, but a geometry each.
+        assertThat(textureSet.getWidth(), is(16));
+        assertThat(textureSet.getHeight(), is(16));
+        assertThat(textureSet.getGeometriesCount(), is(2));
+        assertThat(textureSet.getGeometries(0).getTrimMode(), is(SpriteTrimmingMode.SPRITE_TRIM_MODE_OFF));
+        assertThat(textureSet.getGeometries(1).getTrimMode(), is(SpriteTrimmingMode.SPRITE_TRIM_MODE_4));
+        assertThat(textureSet.getUseGeometries(), is(1));
+
+        // Images sort by path, then pivot, then trim mode number, so the untrimmed entry is first.
+        assertEquals(Arrays.asList(0, 1, 1, 0), textureSet.getFrameIndicesList());
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/textureset/test/TextureSetGeneratorTest.java
@@ -80,7 +80,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, iterator, 0, 0, 0, true, false, null, 0, 0);
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, null, iterator, 0, 0, 0, true, false, null, 0, 0);
         TextureSet textureSet = result.builder.setTexture("").build();
         BufferedImage image = result.images.get(0);
         assertThat(image.getWidth(), is(32));
@@ -110,7 +110,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, iterator, 0, 0, 0, true, false, null, 0, 0);
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, null, iterator, 0, 0, 0, true, false, null, 0, 0);
         BufferedImage image = result.images.get(0);
         assertThat(image.getWidth(), is(32));
         assertThat(image.getHeight(), is(32));
@@ -141,7 +141,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, iterator, 0, 0, 0, true, false, null, 16, 16);
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, null, iterator, 0, 0, 0, true, false, null, 16, 16);
         BufferedImage image0 = result.images.get(0);
         BufferedImage image1 = result.images.get(1);
         assertThat(image0.getWidth(), is(16));
@@ -176,7 +176,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, iterator, 5, 0, 0, true, false, null, 0, 0);
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, null, iterator, 5, 0, 0, true, false, null, 0, 0);
         BufferedImage image = result.images.get(0);
         assertThat(image.getWidth(), is(32));
         assertThat(image.getHeight(), is(64));
@@ -206,7 +206,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, iterator, 0, 0, 0, true, false, null, 0, 0);
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, null, iterator, 0, 0, 0, true, false, null, 0, 0);
 
         TextureSet textureSet = result.builder.setTexture("").build();
 
@@ -233,7 +233,7 @@ public class TextureSetGeneratorTest {
 
         MappedAnimIterator iterator = new MappedAnimIterator(animations, ids);
 
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, iterator, 0, 0, 0, true, false, null, 0, 0);
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, ids, null, iterator, 0, 0, 0, true, false, null, 0, 0);
 
         TextureSet textureSet = result.builder.setTexture("").build();
         assertUVTransform(0.0f, 1.0f, 0.5f, -0.5f, getUvTransforms(result.uvTransforms, textureSet, "anim1", 0));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/AtlasUtil.java
@@ -47,19 +47,30 @@ public class AtlasUtil {
     public static class MappedAnimDesc extends AnimDesc {
         private List<String> paths;
         private List<String> ids;
+        private List<AtlasImageSortKey> keys;
         private boolean singleFrame;
 
         public MappedAnimDesc(String id, List<String> paths, List<String> ids, Playback playback, int fps, boolean flipHorizontal, boolean flipVertical) {
+            this(id, paths, ids, null, playback, fps, flipHorizontal, flipVertical);
+        }
+
+        private MappedAnimDesc(String id, List<String> paths, List<String> ids, List<AtlasImageSortKey> keys, Playback playback, int fps, boolean flipHorizontal, boolean flipVertical) {
             super(id, playback, fps, flipHorizontal, flipVertical);
             this.paths = paths;
             this.ids = ids;
+            this.keys = keys;
             this.singleFrame = false;
         }
 
         public MappedAnimDesc(String id, List<String> paths, List<String> ids) {
+            this(id, paths, ids, null);
+        }
+
+        private MappedAnimDesc(String id, List<String> paths, List<String> ids, List<AtlasImageSortKey> keys) {
             super(id, Playback.PLAYBACK_NONE, 0, false, false);
             this.paths = paths;
             this.ids = ids;
+            this.keys = keys;
             this.singleFrame = true; // This animation is from a single frame animation
         }
 
@@ -70,17 +81,27 @@ public class AtlasUtil {
         public List<String> getPaths() {
             return this.paths;
         }
+
+        private List<AtlasImageSortKey> getKeys() {
+            return this.keys;
+        }
     }
 
     public static class MappedAnimIterator implements AnimIterator {
         final List<MappedAnimDesc> anims;
         final List<String> imagePaths;
+        private final List<AtlasImageSortKey> imageKeys;
         int nextAnimIndex;
         int nextFrameIndex;
 
         public MappedAnimIterator(List<MappedAnimDesc> anims, List<String> imagePaths) {
+            this(anims, imagePaths, null);
+        }
+
+        private MappedAnimIterator(List<MappedAnimDesc> anims, List<String> imagePaths, List<AtlasImageSortKey> imageKeys) {
             this.anims = anims;
             this.imagePaths = imagePaths;
+            this.imageKeys = imageKeys;
         }
 
         @Override
@@ -96,7 +117,12 @@ public class AtlasUtil {
         public Integer nextFrameIndex() { // Return the global index of the image that the frame is using
             MappedAnimDesc anim = anims.get(nextAnimIndex - 1);
             if (nextFrameIndex < anim.getPaths().size()) {
-                return imagePaths.indexOf(anim.getPaths().get(nextFrameIndex++));
+                int frameIndex = nextFrameIndex++;
+                // The same path can have more than one geometry. Use its variant key to find the right one.
+                if (imageKeys != null && anim.getKeys() != null) {
+                    return imageKeys.indexOf(anim.getKeys().get(frameIndex));
+                }
+                return imagePaths.indexOf(anim.getPaths().get(frameIndex));
             }
             return null;
         }
@@ -120,31 +146,52 @@ public class AtlasUtil {
     private static final class AtlasImageSortKey {
         public final String path;
         public final SpriteTrimmingMode mode;
-        public AtlasImageSortKey(String path, SpriteTrimmingMode mode) {
+        public final float pivotX;
+        public final float pivotY;
+        public AtlasImageSortKey(String path, SpriteTrimmingMode mode, float pivotX, float pivotY) {
             this.path = path;
             this.mode = mode;
+            this.pivotX = pivotX;
+            this.pivotY = pivotY;
         }
         @Override
         public int hashCode() {
-            return path.hashCode() + 31 * this.mode.hashCode();
+            int hash = path.hashCode() + 31 * this.mode.hashCode();
+            hash = 31 * hash + Float.hashCode(this.pivotX);
+            hash = 31 * hash + Float.hashCode(this.pivotY);
+            return hash;
         }
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
+            if (!(o instanceof AtlasImageSortKey)) return false;
             AtlasImageSortKey b = (AtlasImageSortKey)o;
-            return this.mode == b.mode && this.path.equals(b.path);
+            return this.mode == b.mode
+                && Float.compare(this.pivotX, b.pivotX) == 0
+                && Float.compare(this.pivotY, b.pivotY) == 0
+                && this.path.equals(b.path);
         }
+    }
+
+    private static AtlasImageSortKey imageKey(AtlasImage image) {
+        return new AtlasImageSortKey(image.getImage(), image.getSpriteTrimMode(), image.getPivotX(), image.getPivotY());
     }
 
     private static void sortImages(List<AtlasImage> images) {
         images.sort(new Comparator<AtlasImage>() {
             @Override
             public int compare(AtlasImage img1, AtlasImage img2) {
-                int nameComparison = img1.getImage().compareTo(img2.getImage());
-                if (nameComparison == 0) {
-                    return Integer.compare(img1.getSpriteTrimMode().getNumber(), img2.getSpriteTrimMode().getNumber());
+                int comparison = img1.getImage().compareTo(img2.getImage());
+                if (comparison == 0) {
+                    comparison = Float.compare(img1.getPivotX(), img2.getPivotX());
                 }
-                return nameComparison;
+                if (comparison == 0) {
+                    comparison = Float.compare(img1.getPivotY(), img2.getPivotY());
+                }
+                if (comparison == 0) {
+                    comparison = Integer.compare(img1.getSpriteTrimMode().getNumber(), img2.getSpriteTrimMode().getNumber());
+                }
+                return comparison;
             }
         });
     }
@@ -155,7 +202,7 @@ public class AtlasUtil {
         List<AtlasImage> images = new ArrayList<AtlasImage>();
         for (AtlasImage image : atlas.getImagesList()) {
 
-            AtlasImageSortKey key = new AtlasImageSortKey(image.getImage(), image.getSpriteTrimMode());
+            AtlasImageSortKey key = imageKey(image);
             if (!uniqueImages.containsKey(key)) {
                 uniqueImages.put(key, image);
                 images.add(image);
@@ -175,7 +222,7 @@ public class AtlasUtil {
 
         for (AtlasAnimation anim : atlas.getAnimationsList()) {
             for (AtlasImage image : anim.getImagesList() ) {
-                AtlasImageSortKey key = new AtlasImageSortKey(image.getImage(), image.getSpriteTrimMode());
+                AtlasImageSortKey key = imageKey(image);
                 if (!uniqueImages.containsKey(key)) {
                     uniqueImages.put(key, image);
                     images.add(image);
@@ -184,6 +231,29 @@ public class AtlasUtil {
         }
         sortImages(images);
         return images;
+    }
+
+    // Maps each geometry to its source image's packed rectangle. Variants share that rectangle.
+    private static List<Integer> geometryToRectIndex(List<AtlasImage> atlasImages) {
+        Map<String, Integer> pathToRectIndex = new HashMap<>();
+        List<Integer> geometryToRectIndex = new ArrayList<Integer>(atlasImages.size());
+        for (AtlasImage image : atlasImages) {
+            Integer rectIndex = pathToRectIndex.get(image.getImage());
+            if (rectIndex == null) {
+                rectIndex = pathToRectIndex.size();
+                pathToRectIndex.put(image.getImage(), rectIndex);
+            }
+            geometryToRectIndex.add(rectIndex);
+        }
+        return geometryToRectIndex;
+    }
+
+    private static List<AtlasImageSortKey> imageKeys(List<AtlasImage> atlasImages) {
+        List<AtlasImageSortKey> keys = new ArrayList<AtlasImageSortKey>(atlasImages.size());
+        for (AtlasImage image : atlasImages) {
+            keys.add(imageKey(image));
+        }
+        return keys;
     }
 
     private static List<IResource> toResources(IResource baseResource, List<String> paths) {
@@ -281,18 +351,21 @@ public class AtlasUtil {
             // Otherwise we couldn't separate two such animations:
             //   anim1: a/1.png, a/2.png ...
             //   anim2: b/1.png, b/2.png ...
+            List<AtlasImageSortKey> frameKeys = new ArrayList<AtlasImageSortKey>();
             for (AtlasImage image : anim.getImagesList()) {
                 framePaths.add(image.getImage());
                 frameIds.add(transformer.transform(image.getImage()));
+                frameKeys.add(imageKey(image));
             }
 
-            animDescs.add(new MappedAnimDesc(anim.getId(), framePaths, frameIds, anim.getPlayback(), anim.getFps(), anim.getFlipHorizontal() != 0, anim.getFlipVertical() != 0));
+            animDescs.add(new MappedAnimDesc(anim.getId(), framePaths, frameIds, frameKeys, anim.getPlayback(), anim.getFps(), anim.getFlipHorizontal() != 0, anim.getFlipVertical() != 0));
         }
         List<AtlasImage> images = new ArrayList<>(atlas.getImagesList());
         sortImages(images);
         for (AtlasImage image : images) {
             String id = transformer.transform(image.getImage());
-            animDescs.add(new MappedAnimDesc(id, Collections.singletonList(image.getImage()), Collections.singletonList(id)));
+            animDescs.add(new MappedAnimDesc(id, Collections.singletonList(image.getImage()), Collections.singletonList(id),
+                                             Collections.singletonList(imageKey(image))));
         }
 
         return animDescs;
@@ -346,9 +419,9 @@ public class AtlasUtil {
         }
 
         List<MappedAnimDesc> animDescs = createAnimDescs(atlas, transformer);
-        MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imageResourcePaths);
+        MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imageResourcePaths, imageKeys(atlasImages));
         try {
-            TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, imageNames, iterator,
+            TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, imageNames, geometryToRectIndex(atlasImages), iterator,
                 Math.max(0, atlas.getMargin()),
                 Math.max(0, atlas.getInnerPadding()),
                 Math.max(0, atlas.getExtrudeBorders()),
@@ -415,9 +488,9 @@ public class AtlasUtil {
         List<BufferedImage> imageDatas = loadImagesFromPaths(imageAbsolutePaths);
 
         List<MappedAnimDesc> animDescs = createAnimDescs(atlas, nameTransformer);
-        MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imagePaths);
+        MappedAnimIterator iterator = new MappedAnimIterator(animDescs, imagePaths, imageKeys(atlasImages));
         try {
-            TextureSetResult result = TextureSetGenerator.generate(imageDatas, atlasImages, imageNames, iterator,
+            TextureSetResult result = TextureSetGenerator.generate(imageDatas, atlasImages, imageNames, geometryToRectIndex(atlasImages), iterator,
                 Math.max(0, atlas.getMargin()),
                 Math.max(0, atlas.getInnerPadding()),
                 Math.max(0, atlas.getExtrudeBorders()),

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -46,6 +46,7 @@ import java.awt.image.Raster;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -443,6 +444,17 @@ public class TextureSetGenerator {
      */
     public static TextureSetResult calculateTextureSetResult(LayoutResult layout, List<SpriteGeometry> imageHulls, int useGeometries,
                                                              AnimIterator iterator) {
+        return calculateTextureSetResult(layout, imageHulls, null, useGeometries, iterator);
+    }
+
+    /**
+     * A geometry can have a different pivot or trim mode without needing another atlas slot.
+     * geometryToRectIndex maps each geometry to its shared packed rectangle. A null mapping keeps
+     * the original one-geometry-per-rectangle behaviour.
+     */
+    public static TextureSetResult calculateTextureSetResult(LayoutResult layout, List<SpriteGeometry> imageHulls,
+                                                             List<Integer> geometryToRectIndex, int useGeometries,
+                                                             AnimIterator iterator) {
 
         TimeProfiler.start("calculateTextureSetResult");
 
@@ -460,15 +472,27 @@ public class TextureSetGenerator {
         // Contract the sizes rectangles (i.e remove the extrudeBorders from them)
         layoutRects = clipBorders(layoutRects, layout.extrudeBorders);
 
-        Pair<TextureSet.Builder, List<UVTransform>> vertexData = buildData(layoutWidth, layoutHeight, layoutRects, iterator);
+        // Texture-set frames use geometry indices, so each geometry needs an entry for its packed rect.
+        List<Rect> geometryRects;
+        if (geometryToRectIndex == null) {
+            geometryRects = layoutRects;
+        } else {
+            geometryRects = new ArrayList<Rect>(geometryToRectIndex.size());
+            for (Integer rectIndex : geometryToRectIndex) {
+                geometryRects.add(layoutRects.get(rectIndex));
+            }
+        }
+
+        Pair<TextureSet.Builder, List<UVTransform>> vertexData = buildData(layoutWidth, layoutHeight, geometryRects, iterator);
 
         vertexData.left.setUseGeometries(useGeometries);
 
         if (imageHulls != null) {
-            for (Rect rect : layoutRects) {
-                SpriteGeometry geometry = imageHulls.get(rect.getIndex());
+            for (int i = 0; i < imageHulls.size(); ++i) {
+                Rect rect = geometryRects.get(i);
+
                 SpriteGeometry.Builder geometryBuilder = TextureSetProto.SpriteGeometry.newBuilder();
-                geometryBuilder.mergeFrom(geometry);
+                geometryBuilder.mergeFrom(imageHulls.get(i));
 
                 TextureSetLayout.Point center = rect.getCenter();
                 geometryBuilder.setCenterX(center.x);
@@ -488,10 +512,18 @@ public class TextureSetGenerator {
                                                     AnimIterator iterator, int margin, int innerPadding, int extrudeBorders,
                                                     boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
 
+        return calculateLayout(images, imageHulls, null, useGeometries, iterator, margin, innerPadding, extrudeBorders,
+                               rotate, useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
+    }
+
+    public static TextureSetResult calculateLayout(List<Rect> images, List<SpriteGeometry> imageHulls, List<Integer> geometryToRectIndex,
+                                                    int useGeometries, AnimIterator iterator, int margin, int innerPadding, int extrudeBorders,
+                                                    boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
+
         LayoutResult layout = calculateLayoutResult(images, margin, innerPadding, extrudeBorders, rotate,
                                                     useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
 
-        return calculateTextureSetResult(layout, imageHulls, useGeometries, iterator);
+        return calculateTextureSetResult(layout, imageHulls, geometryToRectIndex, useGeometries, iterator);
     }
 
     // Public api
@@ -571,7 +603,39 @@ public class TextureSetGenerator {
             int margin, int innerPadding, int extrudeBorders, boolean rotate, boolean useTileGrid, Grid gridSize,
             float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
 
-        List<Rect> imageRects = rectanglesFromImages(images, paths);
+        return generate(images, atlasImages, paths, null, iterator, margin, innerPadding, extrudeBorders,
+                        rotate, useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
+    }
+
+    /**
+     * Maps each geometry to its packed rectangle. This lets pivot and trim variants share one atlas
+     * slot. A null mapping keeps the original one-geometry-per-rectangle behaviour.
+     */
+    public static TextureSetResult generate(List<BufferedImage> images, List<AtlasImage> atlasImages, List<String> paths,
+            List<Integer> geometryToRectIndex, AnimIterator iterator,
+            int margin, int innerPadding, int extrudeBorders, boolean rotate, boolean useTileGrid, Grid gridSize,
+            float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
+
+        // Pack each shared rectangle once.
+        List<BufferedImage> layoutSourceImages = images;
+        List<String> layoutSourcePaths = paths;
+        if (geometryToRectIndex != null) {
+            int rectCount = 0;
+            for (Integer rectIndex : geometryToRectIndex) {
+                rectCount = Math.max(rectCount, rectIndex + 1);
+            }
+            layoutSourceImages = new ArrayList<BufferedImage>(Collections.nCopies(rectCount, (BufferedImage)null));
+            layoutSourcePaths = new ArrayList<String>(Collections.nCopies(rectCount, (String)null));
+            for (int i = 0; i < geometryToRectIndex.size(); ++i) {
+                int rectIndex = geometryToRectIndex.get(i);
+                if (layoutSourceImages.get(rectIndex) == null) {
+                    layoutSourceImages.set(rectIndex, images.get(i));
+                    layoutSourcePaths.set(rectIndex, paths.get(i));
+                }
+            }
+        }
+
+        List<Rect> imageRects = rectanglesFromImages(layoutSourceImages, layoutSourcePaths);
 
         // if all sizes are 0, we still need to generate hull (or rect) data
         // since it will still be part of the new code path if there is another atlas with trimming enabled
@@ -593,7 +657,7 @@ public class TextureSetGenerator {
         }
 
         // The layout step will expand the rect, and possibly rotate them
-        TextureSetResult result = calculateLayout(imageRects, imageHulls, useGeometries, iterator,
+        TextureSetResult result = calculateLayout(imageRects, imageHulls, geometryToRectIndex, useGeometries, iterator,
             margin, innerPadding, extrudeBorders, rotate, useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
 
         for (Layout layout : result.layoutResult.layouts) {
@@ -601,7 +665,7 @@ public class TextureSetGenerator {
             List<Rect> layoutRects           = layout.getRectangles();
 
             for (Rect rect : layoutRects) {
-                BufferedImage image = images.get(rect.getIndex());
+                BufferedImage image = layoutSourceImages.get(rect.getIndex());
 
                 if (innerPadding > 0) {
                     image = TextureUtil.createPaddedImage(image, innerPadding, paddingColour);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/textureset/TextureSetGenerator.java
@@ -441,13 +441,7 @@ public class TextureSetGenerator {
     /**
      * Generate an atlas for individual images and animations. The basic steps of the algorithm are:
      * Create vertex data for each frame (image) in each animation
-     */
-    public static TextureSetResult calculateTextureSetResult(LayoutResult layout, List<SpriteGeometry> imageHulls, int useGeometries,
-                                                             AnimIterator iterator) {
-        return calculateTextureSetResult(layout, imageHulls, null, useGeometries, iterator);
-    }
-
-    /**
+     *
      * A geometry can have a different pivot or trim mode without needing another atlas slot.
      * geometryToRectIndex maps each geometry to its shared packed rectangle. A null mapping keeps
      * the original one-geometry-per-rectangle behaviour.
@@ -508,14 +502,6 @@ public class TextureSetGenerator {
     }
 
     // Deprecated
-    public static TextureSetResult calculateLayout(List<Rect> images, List<SpriteGeometry> imageHulls, int useGeometries,
-                                                    AnimIterator iterator, int margin, int innerPadding, int extrudeBorders,
-                                                    boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
-
-        return calculateLayout(images, imageHulls, null, useGeometries, iterator, margin, innerPadding, extrudeBorders,
-                               rotate, useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
-    }
-
     public static TextureSetResult calculateLayout(List<Rect> images, List<SpriteGeometry> imageHulls, List<Integer> geometryToRectIndex,
                                                     int useGeometries, AnimIterator iterator, int margin, int innerPadding, int extrudeBorders,
                                                     boolean rotate, boolean useTileGrid, Grid gridSize, float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
@@ -596,20 +582,11 @@ public class TextureSetGenerator {
      * @param images list of images
      * @param imagePaths corresponding image-id to previous list
      * @param animations list of animations
+     * @param geometryToRectIndex maps each geometry to its packed rectangle, letting pivot and trim
+     *                            variants share one atlas slot. A null mapping keeps the original
+     *                            one-geometry-per-rectangle behaviour.
      * @param margin internal atlas margin
      * @return {@link AtlasMap}
-     */
-    public static TextureSetResult generate(List<BufferedImage> images, List<AtlasImage> atlasImages, List<String> paths, AnimIterator iterator,
-            int margin, int innerPadding, int extrudeBorders, boolean rotate, boolean useTileGrid, Grid gridSize,
-            float maxPageSizeW, float maxPageSizeH) throws CompileExceptionError {
-
-        return generate(images, atlasImages, paths, null, iterator, margin, innerPadding, extrudeBorders,
-                        rotate, useTileGrid, gridSize, maxPageSizeW, maxPageSizeH);
-    }
-
-    /**
-     * Maps each geometry to its packed rectangle. This lets pivot and trim variants share one atlas
-     * slot. A null mapping keeps the original one-geometry-per-rectangle behaviour.
      */
     public static TextureSetResult generate(List<BufferedImage> images, List<AtlasImage> atlasImages, List<String> paths,
             List<Integer> geometryToRectIndex, AnimIterator iterator,

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/tile/TileSetGenerator.java
@@ -141,7 +141,7 @@ public class TileSetGenerator {
         // Since all the images already are positioned optimally in a grid,
         // we tell TextureSetGenerator to NOT do its own packing and use this grid directly.
         Grid grid_size = new Grid(metrics.tilesPerRow, metrics.tilesPerColumn);
-        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, names, iterator, 0,
+        TextureSetResult result = TextureSetGenerator.generate(images, atlasImages, names, null, iterator, 0,
                 tileSet.getInnerPadding(),
                 tileSet.getExtrudeBorders(), false, true, grid_size, 0, 0);
 

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -176,17 +176,16 @@
 (defn- atlas-rect->editor-rect [rect]
   (types/->Rect (:path rect) (:x rect) (:y rect) (:width rect) (:height rect)))
 
-(g/defnk produce-atlas-scene-info [layout-size image-path->rect]
+(g/defnk produce-atlas-scene-info [layout-size image->rect]
   {:layout-size layout-size
-   :image-path->rect image-path->rect})
+   :image->rect image->rect})
 
 (g/defnk produce-animation-scene-info [atlas-scene-info updatable]
   (assoc atlas-scene-info :updatable updatable))
 
-(g/defnk produce-image-scene [_node-id image-resource order scene-info]
-  (let [{:keys [layout-size image-path->rect updatable]} scene-info
-        path (resource/proj-path image-resource)
-        rect (get image-path->rect path)
+(g/defnk produce-image-scene [_node-id atlas-image order scene-info]
+  (let [{:keys [layout-size image->rect updatable]} scene-info
+        rect (get image->rect atlas-image)
         editor-rect (atlas-rect->editor-rect rect)
         [layout-width layout-height] layout-size
         page-index (:page rect)
@@ -723,25 +722,21 @@
                         [y (- x)])))
         vertices))
 
-(g/defnk produce-image-path->rect
-  [layout-size layout-rects geometry->layout-rect-index texture-set]
-  (let [[w h] layout-size
+(g/defnk produce-image->rect
+  [layout-size layout-rects geometry-images geometry->layout-rect-index texture-set]
+  (let [[_ h] layout-size
         geometries (:geometries texture-set)
-
-        layout-rect-index->geometry (reduce-kv (fn [acc geometry-index rect-index]
-                                                 (if (contains? acc rect-index)
-                                                   acc
-                                                   (assoc acc rect-index (get geometries geometry-index))))
-                                               {}
-                                               geometry->layout-rect-index)]
-    (into {} (map (fn [{:keys [path x y width height index page]}]
-                    (let [geometry (layout-rect-index->geometry index)
-                          rotated-vertices (if (:rotated geometry)
-                                             (rotate-vertices-90-cw (:vertices geometry))
-                                             (:vertices geometry))]
-                      [path (->AtlasRect path x (- h height y) width height page
-                                         (assoc geometry :vertices rotated-vertices))])))
-          layout-rects)))
+        rect-index->rect (into {} (map (juxt :index identity)) layout-rects)]
+    (into {}
+          (map-indexed (fn [geometry-index image]
+                         (let [{:keys [path x y width height page]} (rect-index->rect (geometry->layout-rect-index geometry-index))
+                               geometry (get geometries geometry-index)
+                               rotated-vertices (if (:rotated geometry)
+                                                  (rotate-vertices-90-cw (:vertices geometry))
+                                                  (:vertices geometry))]
+                           [image (->AtlasRect path x (- h height y) width height page
+                                               (assoc geometry :vertices rotated-vertices))])))
+          geometry-images)))
 
 (defn- atlas-outline-sort-by-fn [basis v]
   ;; NOTE: unsafe basis from node output! Only use for node type access!
@@ -814,6 +809,7 @@
   (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
   (output uv-transforms    g/Any               (g/fnk [layout-data] (:uv-transforms layout-data)))
   (output layout-rects     g/Any               (g/fnk [layout-data] (:rects layout-data)))
+  (output geometry-images  g/Any               (g/fnk [layout-data] (:geometry-images layout-data)))
   (output geometry->layout-rect-index g/Any    (g/fnk [layout-data] (:geometry->layout-rect-index layout-data)))
 
   (output texture-page-count g/Int (g/fnk [_node-id layout-data max-page-size exclude-gles-sm100]
@@ -842,7 +838,7 @@
                   texture))))
 
   (output anim-data        g/Any               :cached produce-anim-data)
-  (output image-path->rect g/Any               :cached produce-image-path->rect)
+  (output image->rect      g/Any               :cached produce-image->rect)
 
   (output anim-ids         g/Any               :cached (g/fnk [animation-ids] (filter some? animation-ids)))
   (output id-counts        NameCounts          :cached (g/fnk [anim-ids] (frequencies anim-ids)))

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -727,16 +727,15 @@
   (let [[_ h] layout-size
         geometries (:geometries texture-set)
         rect-index->rect (into {} (map (juxt :index identity)) layout-rects)]
-    (into {}
-          (map-indexed (fn [geometry-index image]
-                         (let [{:keys [path x y width height page]} (rect-index->rect (geometry->layout-rect-index geometry-index))
-                               geometry (get geometries geometry-index)
-                               rotated-vertices (if (:rotated geometry)
-                                                  (rotate-vertices-90-cw (:vertices geometry))
-                                                  (:vertices geometry))]
-                           [image (->AtlasRect path x (- h height y) width height page
-                                               (assoc geometry :vertices rotated-vertices))])))
-          geometry-images)))
+    (coll/into-> geometry-images {}
+      (map-indexed (fn [geometry-index image]
+                     (let [{:keys [path x y width height page]} (rect-index->rect (geometry->layout-rect-index geometry-index))
+                           geometry (get geometries geometry-index)
+                           rotated-vertices (if (:rotated geometry)
+                                              (rotate-vertices-90-cw (:vertices geometry))
+                                              (:vertices geometry))]
+                       [image (->AtlasRect path x (- h height y) width height page
+                                           (assoc geometry :vertices rotated-vertices))]))))))
 
 (defn- atlas-outline-sort-by-fn [basis v]
   ;; NOTE: unsafe basis from node output! Only use for node type access!

--- a/editor/src/clj/editor/atlas.clj
+++ b/editor/src/clj/editor/atlas.clj
@@ -304,7 +304,9 @@
 
   (output atlas-image Image (g/fnk [_node-id image-resource maybe-image-size pivot-x pivot-y sprite-trim-mode]
                               (with-meta
-                                (Image. image-resource nil (:width maybe-image-size) (:height maybe-image-size) pivot-x pivot-y sprite-trim-mode)
+                                (Image. image-resource nil
+                                        (:width maybe-image-size) (:height maybe-image-size)
+                                        (float pivot-x) (float pivot-y) sprite-trim-mode)
                                 {:error-node-id _node-id})))
   (output atlas-images [Image] (g/fnk [atlas-image] [atlas-image]))
   (output animation Animation (g/fnk [atlas-image id]
@@ -579,9 +581,9 @@
     {:info-text (format "%d x %d (%s profile)" width height (:name texture-profile))
      :children (into page-scenes child-scenes)}))
 
-(defn- generate-texture-set-data [{:keys [digest-ignored/error-node-id animations all-atlas-images margin inner-padding extrude-borders max-page-size]}]
+(defn- generate-texture-set-data [{:keys [digest-ignored/error-node-id animations atlas-images-variants unique-atlas-images margin inner-padding extrude-borders max-page-size]}]
   (try
-    (texture-set-gen/atlas->texture-set-data animations all-atlas-images margin inner-padding extrude-borders max-page-size)
+    (texture-set-gen/atlas->texture-set-data animations atlas-images-variants unique-atlas-images margin inner-padding extrude-borders max-page-size)
     (catch Exception error
       (g/->error error-node-id :max-page-size :fatal nil (.getMessage error)))))
 
@@ -602,7 +604,7 @@
     texture/non-paged-page-count))
 
 (g/defnk produce-layout-data-generator
-  [_node-id animation-images all-atlas-images extrude-borders inner-padding margin max-page-size :as args]
+  [_node-id animation-images atlas-images-variants unique-atlas-images extrude-borders inner-padding margin max-page-size :as args]
   ;; The TextureSetGenerator.calculateLayout() method inherited from Bob also
   ;; compiles a TextureSetProto$TextureSet including the animation data in
   ;; addition to generating the layout. This means that modifying a property on
@@ -625,7 +627,9 @@
 
 (g/defnk produce-packed-page-images-generator
   [_node-id extrude-borders image-resources inner-padding margin layout-data-generator max-page-size texture-page-count]
-  (let [flat-image-resources (filterv some? (flatten image-resources))
+  (let [flat-image-resources (coll/into-> (flatten image-resources) []
+                               (filter some?)
+                               (util/distinct-by resource/proj-path))
         image-sha1s (pmap (fn [resource]
                             (resource-io/with-error-translation resource _node-id nil
                               (resource/resource->path-inclusive-sha1 resource)))
@@ -665,7 +669,7 @@
   ;; contain the animation metadata since it was produced from fake animations.
   ;; In order to produce a valid TextureSetResult, we complete the protobuf
   ;; animations inside the embedded TextureSet with our animation properties.
-  [animations layout-data all-atlas-images rename-patterns]
+  [animations layout-data atlas-images-variants rename-patterns]
   (let [incomplete-ddf-texture-set (:texture-set layout-data)
         incomplete-ddf-animations (:animations incomplete-ddf-texture-set)
         animation-present-in-ddf? (comp coll/not-empty :images)
@@ -686,7 +690,7 @@
         fixed-image-name-hashes (-> []
                                     (into
                                       (map #(-> % :path (texture-set-gen/resource-id rename-patterns) murmur/hash64))
-                                      all-atlas-images)
+                                      atlas-images-variants)
                                     (into
                                       (mapcat
                                         (fn [{:keys [id images]}]
@@ -720,11 +724,18 @@
         vertices))
 
 (g/defnk produce-image-path->rect
-  [layout-size layout-rects texture-set]
+  [layout-size layout-rects geometry->layout-rect-index texture-set]
   (let [[w h] layout-size
-        geometries (:geometries texture-set)]
+        geometries (:geometries texture-set)
+
+        layout-rect-index->geometry (reduce-kv (fn [acc geometry-index rect-index]
+                                                 (if (contains? acc rect-index)
+                                                   acc
+                                                   (assoc acc rect-index (get geometries geometry-index))))
+                                               {}
+                                               geometry->layout-rect-index)]
     (into {} (map (fn [{:keys [path x y width height index page]}]
-                    (let [geometry (get geometries index)
+                    (let [geometry (layout-rect-index->geometry index)
                           rotated-vertices (if (:rotated geometry)
                                              (rotate-vertices-90-cw (:vertices geometry))
                                              (:vertices geometry))]
@@ -789,8 +800,12 @@
   (output texture-profile g/Any (g/fnk [texture-profiles resource]
                                   (tex-gen/match-texture-profile texture-profiles (resource/proj-path resource))))
 
-  (output all-atlas-images [Image] :cached (g/fnk [animation-images]
-                                             (into [] (distinct) (flatten animation-images))))
+  (output unique-atlas-images [Image] :cached (g/fnk [animation-images]
+                                                (into [] (util/distinct-by (comp resource/proj-path :path)) (flatten animation-images))))
+
+  (output atlas-images-variants [Image] :cached (g/fnk [animation-images]
+                                                  (into [] (distinct) (flatten animation-images))))
+
 
   (output layout-data-generator g/Any          produce-layout-data-generator)
   (output texture-set-data g/Any               :cached produce-texture-set-data)
@@ -799,6 +814,7 @@
   (output texture-set      g/Any               (g/fnk [texture-set-data] (:texture-set texture-set-data)))
   (output uv-transforms    g/Any               (g/fnk [layout-data] (:uv-transforms layout-data)))
   (output layout-rects     g/Any               (g/fnk [layout-data] (:rects layout-data)))
+  (output geometry->layout-rect-index g/Any    (g/fnk [layout-data] (:geometry->layout-rect-index layout-data)))
 
   (output texture-page-count g/Int (g/fnk [_node-id layout-data max-page-size exclude-gles-sm100]
                                      (let [page-count (calculate-texture-page-count layout-data max-page-size)]

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -197,6 +197,7 @@
         (doto (.builder result)
           (.setTexture "unknown"))
         (assoc (TextureSetResult->result result)
+          :geometry-images geometry-images
           :geometry->layout-rect-index geometry->layout-rect-index)))))
 
 (defn- calc-tile-start [{:keys [spacing margin]} size tile-index]

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -152,15 +152,20 @@
           (TextureSetGenerator/buildConvexHull buffered-image pivot-x pivot-y (sprite-trim-mode->enum sprite-trim-mode)))))))
 
 (defn atlas->texture-set-data
-  [animations images margin inner-padding extrude-borders max-page-size]
+  [animations geometry-images layout-images margin inner-padding extrude-borders max-page-size]
   ;; NOTE: Images order matters when generating the layouts, especially if they are of the same size.
   ;; Since the SHA1 for the packed-page-images-generator is insensitive to order, things could get out of sync
-  (let [images (sort-by #(-> % :path resource/proj-path) images)
-        sprite-geometries (mapv make-image-sprite-geometry images)]
-    (g/precluding-errors sprite-geometries
-      (let [img-to-index (into {}
-                               (map-indexed #(pair %2 (Integer/valueOf ^int %1)))
-                               images)
+  (let [geometry-images (vec (sort-by (juxt #(-> % :path resource/proj-path)
+                                            :pivot-x
+                                            :pivot-y
+                                            #(protobuf/pb-enum->int (sprite-trim-mode->enum (:sprite-trim-mode %))))
+                                      geometry-images))
+        layout-images (vec (sort-by #(-> % :path resource/proj-path) layout-images))
+        geometries (mapv make-image-sprite-geometry geometry-images)]
+    (g/precluding-errors geometries
+      (let [geometry-image->index (into {}
+                                        (map-indexed #(pair %2 (Integer/valueOf ^int %1)))
+                                        geometry-images)
             anims-atom (atom animations)
             anim-imgs-atom (atom [])
             anim-iterator (reify TextureSetGenerator$AnimIterator
@@ -172,21 +177,27 @@
                             (nextFrameIndex [_this]
                               (let [img (first @anim-imgs-atom)]
                                 (swap! anim-imgs-atom rest)
-                                (img-to-index img)))
+                                (geometry-image->index img)))
                             ; This generator is run with fake animation (i.e. no valid id's)
                             ; See atlas.clj produce-texture-set-data for the patchup details
                             (getFrameId [_this] "")
                             (rewind [_this]
                               (reset! anims-atom animations)
                               (reset! anim-imgs-atom [])))
-            rects (mapv texture-set-layout-rect images)
-            use-geometries (if (every? #(= :sprite-trim-mode-off (:sprite-trim-mode %)) images) 0 1)
+            layout-rects (mapv texture-set-layout-rect layout-images)
+            path->layout-rect-index (into {}
+                                          (map-indexed #(pair (-> %2 :path resource/proj-path) (Integer/valueOf ^int %1)))
+                                          layout-images)
+            geometry->layout-rect-index (mapv #(path->layout-rect-index (-> % :path resource/proj-path))
+                                              geometry-images)
+            use-geometries (if (every? #(= :sprite-trim-mode-off (:sprite-trim-mode %)) geometry-images) 0 1)
             result (TextureSetGenerator/calculateLayout
-                     rects sprite-geometries use-geometries anim-iterator margin inner-padding extrude-borders
+                     layout-rects geometries geometry->layout-rect-index use-geometries anim-iterator margin inner-padding extrude-borders
                      true false nil (get max-page-size 0) (get max-page-size 1))]
         (doto (.builder result)
           (.setTexture "unknown"))
-        (TextureSetResult->result result)))))
+        (assoc (TextureSetResult->result result)
+          :geometry->layout-rect-index geometry->layout-rect-index)))))
 
 (defn- calc-tile-start [{:keys [spacing margin]} size tile-index]
   (let [actual-tile-size (+ size spacing (* 2 margin))]

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -18,7 +18,7 @@
             [editor.protobuf :as protobuf]
             [editor.resource :as resource]
             [editor.resource-io :as resource-io]
-            [util.coll :refer [pair]])
+            [util.coll :as coll :refer [pair]])
   (:import [com.dynamo.bob.pipeline AtlasUtil]
            [com.dynamo.bob.textureset TextureSetGenerator TextureSetGenerator$AnimDesc TextureSetGenerator$AnimIterator TextureSetGenerator$LayoutResult TextureSetGenerator$TextureSetResult TextureSetLayout$Grid TextureSetLayout$Layout TextureSetLayout$Rect]
            [com.dynamo.bob.tile ConvexHull TileSetUtil TileSetUtil$Metrics]
@@ -190,7 +190,7 @@
                                           layout-images)
             geometry->layout-rect-index (mapv #(path->layout-rect-index (-> % :path resource/proj-path))
                                               geometry-images)
-            use-geometries (if (every? #(= :sprite-trim-mode-off (:sprite-trim-mode %)) geometry-images) 0 1)
+            use-geometries (if (coll/every? #(= :sprite-trim-mode-off (:sprite-trim-mode %)) geometry-images) 0 1)
             result (TextureSetGenerator/calculateLayout
                      layout-rects geometries geometry->layout-rect-index use-geometries anim-iterator margin inner-padding extrude-borders
                      true false nil (get max-page-size 0) (get max-page-size 1))]

--- a/editor/src/clj/editor/pipeline/texture_set_gen.clj
+++ b/editor/src/clj/editor/pipeline/texture_set_gen.clj
@@ -319,6 +319,7 @@
         result (TextureSetGenerator/calculateTextureSetResult
                  layout-result
                  sprite-geometries
+                 nil
                  use-geometries
                  anim-iterator)]
     (doto (.builder result)

--- a/editor/test/integration/atlas_test.clj
+++ b/editor/test/integration/atlas_test.clj
@@ -16,12 +16,14 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
             [dynamo.graph :as g]
+            [editor.atlas :as atlas]
             [editor.defold-project :as project]
             [editor.fs :as fs]
             [editor.texture-util :as texture-util]
             [editor.workspace :as workspace]
             [integration.test-util :as test-util]
-            [support.test-support :as test-support]))
+            [support.test-support :as test-support]
+            [util.coll :as coll]))
 
 (deftest valid-fps
   (test-util/with-loaded-project
@@ -58,6 +60,48 @@
                "diamond_dogs"
                "test_anim"}
              animation-ids-in-ddf)))))
+
+(deftest image-variants-share-a-rect-but-keep-their-own-geometry
+  (test-support/with-clean-system
+    (let [workspace (test-util/setup-scratch-workspace! world "test/resources/image_project")
+          project (test-util/setup-project! workspace)
+          resource (test-util/make-resource!
+                     workspace "/main/variants.atlas"
+                     {:margin 0
+                      :extrude-borders 0
+                      :inner-padding 0
+                      :images [{:image "/images/diamond.png"}]
+                      :animations [{:id "variant"
+                                    :images [{:image "/images/diamond.png"
+                                              :pivot-x 0.0
+                                              :sprite-trim-mode :sprite-trim-mode-6}]}]})
+          _ (workspace/resource-sync! workspace)
+          atlas (project/get-resource-node project resource)
+          image->rect (g/node-value atlas :image->rect)
+          rects (coll/vals image->rect)]
+
+      (testing "The source image is packed once"
+        (is (= 1 (count (g/node-value atlas :layout-rects))))
+        (is (= 1 (count (into #{} (map (juxt :x :y :width :height :page)) rects)))))
+
+      (testing "But each entry keeps its own geometry"
+        (is (= 2 (count image->rect)))
+        (is (= #{0.0 0.5} (into #{} (map (comp double :pivot-x)) (coll/keys image->rect))))
+        (is (= #{:sprite-trim-mode-off :sprite-trim-mode-6} (into #{} (map :sprite-trim-mode) (coll/keys image->rect))))
+        (is (= #{-0.5 0.0} (into #{} (map (comp double :pivot-x :geometry)) rects)))
+        (is (= #{:sprite-trim-mode-off :sprite-trim-mode-6} (into #{} (map (comp :trim-mode :geometry)) rects))))
+
+      (testing "And the scene of each image node renders its own geometry"
+        (let [image-nodes (into []
+                                (comp (map :node-id)
+                                      (filter #(g/node-instance? atlas/AtlasImage %)))
+                                (tree-seq :children :children (g/node-value atlas :node-outline)))
+              scene-trim-modes (into #{}
+                                     (map (fn [image-node]
+                                            (-> (g/node-value image-node :scene) :renderable :user-data :rect :geometry :trim-mode)))
+                                     image-nodes)]
+          (is (= 2 (count image-nodes)))
+          (is (= #{:sprite-trim-mode-off :sprite-trim-mode-6} scene-trim-modes)))))))
 
 (deftest sprite-trim-mode-image-io-error
   (test-support/with-clean-system


### PR DESCRIPTION
A bug was fixed where reusing the same atlas image for different animations but with a different pivot and/or trim mode would end up sharing the same geometry. Now animations with different pivot/trim will retain their own geometry while using the same image.

Fixes #7403
Fixes #13019

### Technical changes

It turned out to indeed need changes to both the editor and bob. On the editor side, it was treating an image with different pivot/trim as a separate image to pack. Bob was deduping by path + trim, so if changing the pivot, one would collapse onto the other, so you couldn't select the duplicated image from the outline.