### PR TITLE
Fix build failure when dependency metadata is enabled

### DIFF
--- a/editor/src/clj/util/digestable.clj
+++ b/editor/src/clj/util/digestable.clj
@@ -183,7 +183,7 @@
   (digest-raw! "}" writer))
 
 (defn- to-sorted-set [set]
-  {:pre [(set? set)]}
+  {:pre [(instance? java.util.Set set)]}
   (if (or (sorted? set)
           (< (count set) 2))
     set
@@ -231,7 +231,7 @@
   (digest! [value writer opts]
     (digest-tagged! 'Function (fn->symbol value) writer opts))
 
-  clojure.lang.IPersistentSet
+  java.util.Set
   (digest! [value writer opts]
     (digest-set! value writer opts))
 

--- a/editor/test/integration/build_test.clj
+++ b/editor/test/integration/build_test.clj
@@ -32,6 +32,7 @@
             [integration.test-util :refer [with-loaded-project] :as test-util]
             [support.test-support :refer [with-clean-system]]
             [util.coll :as coll]
+            [util.http-server :as http-server]
             [util.murmur :as murmur])
   (:import [com.dynamo.bob.util DependencyMetadata Library$Problem$Missing Library$Result TextureUtil]
            [com.dynamo.font.proto GlyphBankProto$GlyphBank]
@@ -1002,6 +1003,22 @@
       (with-setting ["project" "dependencies_metadata"] false
         (is (nil? (:error (project-build! project game-project))))
         (is (false? (.exists build-metadata-file)))))))
+
+(deftest build-with-dependencies-metadata-from-library
+  (with-open [server (http-server/start! test-util/lib-server-handler)]
+    (let [dependency-url (test-util/lib-server-uri server "lib_resource_project")
+          property-name "defold.extension.test-dependency.url"]
+      (System/setProperty property-name dependency-url)
+      (try
+        (test-util/with-scratch-project "test/resources/dependencies_metadata_project"
+          (let [game-project (test-util/resource-node project "/game.project")
+                build-result (project-build! project game-project)]
+            (when (is (nil? (:error build-result)))
+              (let [metadata-json (slurp (build-path workspace DependencyMetadata/OUTPUT_PATH))]
+                (is (string/includes? metadata-json dependency-url))
+                (is (string/includes? metadata-json "\"payload-sha1\""))))))
+        (finally
+          (System/clearProperty property-name))))))
 
 (deftest build-with-ssl-certificates
   (with-loaded-project "test/resources/custom_resources_project"

--- a/editor/test/resources/dependencies_metadata_project/game.project
+++ b/editor/test/resources/dependencies_metadata_project/game.project
@@ -1,0 +1,10 @@
+[project]
+title = Dependencies Metadata Project
+dependencies_metadata = 1
+dependencies#0 = {{defold.extension.test-dependency.url}}
+
+[bootstrap]
+main_collection = /main.collectionc
+
+[input]
+game_binding = /builtins/input/all.input_bindingc

--- a/editor/test/resources/dependencies_metadata_project/main.collection
+++ b/editor/test/resources/dependencies_metadata_project/main.collection
@@ -1,0 +1,1 @@
+name: "Main collection"


### PR DESCRIPTION
Building with dependency metadata enabled no longer fails for libraries that declare included directories.

Fix #13080