### PR TITLE
WebGPU consolidation

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderProgramBuilderTest.java
@@ -581,11 +581,23 @@ public class ShaderProgramBuilderTest extends AbstractProtoBuilderTest {
             "{\n" +
             "   color_out = texture(texture_sampler, var_texcoord0.xy);\n" +
             "}\n";
+        ShaderDesc webShaderDesc = compileShaderWithCompiler(
+            getProject().getShaderCompiler(Platform.WasmWeb), shaderAdapters, "manifest_webgpu_sampler", samplerSource);
         checkOnlyExpectedLanguages(
-            compileShaderWithCompiler(getProject().getShaderCompiler(Platform.WasmWeb), shaderAdapters, "manifest_webgpu_sampler", samplerSource),
+            webShaderDesc,
             ShaderDesc.Language.LANGUAGE_GLES_SM300,
             ShaderDesc.Language.LANGUAGE_GLES_SM100,
             ShaderDesc.Language.LANGUAGE_WGSL);
+
+        // WGSL requires separate texture/sampler resources, but including that
+        // variant must not rename the combined sampler used by WebGL fallback.
+        for (ShaderDesc.Language language : List.of(
+                ShaderDesc.Language.LANGUAGE_GLES_SM300,
+                ShaderDesc.Language.LANGUAGE_GLES_SM100)) {
+            String glslSource = getShaderByLanguage(webShaderDesc, language).getSource().toStringUtf8();
+            assertTrue("WebGL sampler name must match shared reflection for " + language,
+                glslSource.contains("sampler2D texture_sampler"));
+        }
 
         shaderAdapters = Project.getShaderAdaptersOption(Platform.X86_64MacOS, List.of(
             platformSettings("excludeSymbols", List.of("GraphicsAdapterVulkan"))));

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
@@ -1229,7 +1229,6 @@ var Module = {
             var errorObject = Module.prepareErrorObject(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno, errorEvent.error);
             Module.ccall('JSWriteDump', 'null', ['string'], [JSON.stringify(errorObject.stack)]);
         });
-        Module._isEngineLoaded = true;
         Module.setupCanvas(appCanvasId);
 
         Module.arguments = CUSTOM_PARAMETERS["engine_arguments"];
@@ -1245,6 +1244,9 @@ var Module = {
         // starting Wasm so WebGPUIsSupported() can use the cached result.
         Module.probeWebGPUSupport(function() {
             if (Module.hasWebGLSupport() || Module.hasWebGPUSupport()) {
+                // Do not let archive or persistent-storage callbacks start the
+                // engine until the asynchronous WebGPU probe has completed.
+                Module._isEngineLoaded = true;
                 Module.canvas.focus();
 
                 Module.canvas.addEventListener("webglcontextlost", function(event) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/resources/web/dmloader.js
@@ -1160,20 +1160,40 @@ var Module = {
         return { stack:stack, message:message };
     },
 
-    hasWebGPUSupport: function() {
-        var webgpu_support = false;
+    probeWebGPUSupport: function(callback) {
+        Module._webgpuAdapterAvailable = false;
+        var can_probe_adapter = false;
+
         try {
-            var canvas = document.createElement("canvas");
-            var webgpu = canvas.getContext("webgpu");
-            if (webgpu && webgpu instanceof GPUCanvasContext) {
-                webgpu_support = true;
+            if (typeof navigator !== "undefined" && navigator.gpu && typeof navigator.gpu.requestAdapter === "function") {
+                var canvas = document.createElement("canvas");
+                can_probe_adapter = !!canvas.getContext("webgpu");
             }
         } catch (error) {
             console.log("An error occurred while detecting WebGPU support: " + error);
-            webgpu_support = false;
         }
 
-        return webgpu_support;
+        if (!can_probe_adapter) {
+            callback();
+            return;
+        }
+
+        try {
+            navigator.gpu.requestAdapter().then(function(adapter) {
+                Module._webgpuAdapterAvailable = adapter !== null && typeof adapter !== "undefined";
+                callback();
+            }, function(error) {
+                console.log("An error occurred while detecting WebGPU support: " + error);
+                callback();
+            });
+        } catch (error) {
+            console.log("An error occurred while detecting WebGPU support: " + error);
+            callback();
+        }
+    },
+
+    hasWebGPUSupport: function() {
+        return Module._webgpuAdapterAvailable === true;
     },
 
     hasWebGLSupport: function() {
@@ -1220,35 +1240,40 @@ var Module = {
         }
         Module.fullScreenContainer = fullScreenContainer || Module.canvas;
 
-        if (Module.hasWebGLSupport() || Module.hasWebGPUSupport()) {
-            Module.canvas.focus();
+        // Adapter selection in the engine is synchronous, while WebGPU's only
+        // reliable availability check is requestAdapter(). Resolve it before
+        // starting Wasm so WebGPUIsSupported() can use the cached result.
+        Module.probeWebGPUSupport(function() {
+            if (Module.hasWebGLSupport() || Module.hasWebGPUSupport()) {
+                Module.canvas.focus();
 
-            Module.canvas.addEventListener("webglcontextlost", function(event) {
-                event.preventDefault();
-                dmRenderer.rendererContextEvent(dmRenderer.CONTEXT_LOST_EVENT);
-            }, false);
-            Module.canvas.addEventListener("webglcontextrestored", function(event) {
-                dmRenderer.rendererContextEvent(dmRenderer.CONTEXT_RESTORED_EVENT);
-            }, false);
-            // Add context menu hide-handler if requested
-            if (CUSTOM_PARAMETERS["disable_context_menu"])
-            {
-                Module.canvas.oncontextmenu = function(e) {
-                    e.preventDefault();
+                Module.canvas.addEventListener("webglcontextlost", function(event) {
+                    event.preventDefault();
+                    dmRenderer.rendererContextEvent(dmRenderer.CONTEXT_LOST_EVENT);
+                }, false);
+                Module.canvas.addEventListener("webglcontextrestored", function(event) {
+                    dmRenderer.rendererContextEvent(dmRenderer.CONTEXT_RESTORED_EVENT);
+                }, false);
+                // Add context menu hide-handler if requested
+                if (CUSTOM_PARAMETERS["disable_context_menu"])
+                {
+                    Module.canvas.oncontextmenu = function(e) {
+                        e.preventDefault();
+                    };
+                }
+                Module._preloadAndCallMain();
+            } else {
+                // "Unable to start game, WebGL not supported"
+                ProgressUpdater.complete();
+                Module.setStatus = function(text) {
+                    if (text) Module.printErr('[missing WebGL] ' + text);
                 };
-            }
-            Module._preloadAndCallMain();
-        } else {
-            // "Unable to start game, WebGL not supported"
-            ProgressUpdater.complete();
-            Module.setStatus = function(text) {
-                if (text) Module.printErr('[missing WebGL] ' + text);
-            };
 
-            if (typeof CUSTOM_PARAMETERS["unsupported_webgl_callback"] === "function") {
-                CUSTOM_PARAMETERS["unsupported_webgl_callback"]();
+                if (typeof CUSTOM_PARAMETERS["unsupported_webgl_callback"] === "function") {
+                    CUSTOM_PARAMETERS["unsupported_webgl_callback"]();
+                }
             }
-        }
+        });
     },
 
     onArchiveFileLoaded: function(file) {

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1280,7 +1280,7 @@ static void requestDeviceCallback(WGPURequestDeviceStatus status, WGPUDevice dev
 {
     TRACE_CALL;
     WebGPUContext* context = (WebGPUContext*)userdata;
-    if (device)
+    if (status == WGPURequestDeviceStatus_Success && device)
     {
         context->m_Device = device;
 #if !defined(DM_GRAPHICS_WEBGPU2)
@@ -1288,6 +1288,8 @@ static void requestDeviceCallback(WGPURequestDeviceStatus status, WGPUDevice dev
 #endif
         wgpuDeviceGetLimits(context->m_Device, &context->m_DeviceLimits);
         context->m_Queue = wgpuDeviceGetQueue(context->m_Device);
+
+        bool surface_initialized = false;
         {
 #if defined(DM_GRAPHICS_WEBGPU2)
             WGPUSurfaceDescriptor surface_desc = WGPU_SURFACE_DESCRIPTOR_INIT;
@@ -1306,27 +1308,48 @@ static void requestDeviceCallback(WGPURequestDeviceStatus status, WGPUDevice dev
 #endif
             context->m_Surface = wgpuInstanceCreateSurface(context->m_Instance, &surface_desc);
         }
+
+        if (!context->m_Surface)
+        {
+            dmLogError("WebGPU: Unable to create surface");
+        }
 #if defined(DM_GRAPHICS_WEBGPU2)
+        else
         {
             WGPUSurfaceCapabilities capabilities = WGPU_SURFACE_CAPABILITIES_INIT;
-            wgpuSurfaceGetCapabilities(context->m_Surface, context->m_Adapter, &capabilities);
-            assert(capabilities.formatCount > 0);
-            context->m_Format = capabilities.formats[0];
+            const WGPUStatus capabilities_status = wgpuSurfaceGetCapabilities(context->m_Surface, context->m_Adapter, &capabilities);
+            if (capabilities_status == WGPUStatus_Success && capabilities.formatCount > 0 && capabilities.formats)
+            {
+                context->m_Format = capabilities.formats[0];
+                surface_initialized = context->m_Format != WGPUTextureFormat_Undefined;
+            }
             wgpuSurfaceCapabilitiesFreeMembers(capabilities);
+            if (!surface_initialized)
+                dmLogError("WebGPU: Unable to query a supported surface format");
         }
 #else
-        context->m_Format = wgpuSurfaceGetPreferredFormat(context->m_Surface, context->m_Adapter);
+        else
+        {
+            context->m_Format = wgpuSurfaceGetPreferredFormat(context->m_Surface, context->m_Adapter);
+            surface_initialized = context->m_Format != WGPUTextureFormat_Undefined;
+            if (!surface_initialized)
+                dmLogError("WebGPU: Unable to query a supported surface format");
+        }
 #endif
-        WebGPUConfigure(context, context->m_OriginalWidth, context->m_OriginalHeight);
 
-        dmLogInfo("WebGPU: Created device");
+        if (surface_initialized)
+        {
+            WebGPUConfigure(context, context->m_OriginalWidth, context->m_OriginalHeight);
+            dmLogInfo("WebGPU: Created device");
+        }
     }
     else
     {
 #if defined(DM_GRAPHICS_WEBGPU2)
-        dmLogError("WebGPU: Unable to create device %s", message.data ? message.data : "unknown");
+        dmLogError("WebGPU: Unable to create device (%d): %.*s", (int)status,
+                   message.data ? (int)message.length : 7, message.data ? message.data : "unknown");
 #else
-        dmLogError("WebGPU: Unable to create device %s", message);
+        dmLogError("WebGPU: Unable to create device (%d): %s", (int)status, message ? message : "unknown");
 #endif
     }
     context->m_InitComplete = true;
@@ -1340,7 +1363,7 @@ static void instanceRequestAdapterCallback(WGPURequestAdapterStatus status, WGPU
 {
     TRACE_CALL;
     WebGPUContext* context = (WebGPUContext*)userdata;
-    if (adapter)
+    if (status == WGPURequestAdapterStatus_Success && adapter)
     {
         context->m_Adapter = adapter;
         wgpuAdapterGetLimits(context->m_Adapter, &context->m_AdapterLimits);
@@ -1388,9 +1411,10 @@ static void instanceRequestAdapterCallback(WGPURequestAdapterStatus status, WGPU
     else
     {
 #if defined(DM_GRAPHICS_WEBGPU2)
-        dmLogError("WebGPU: Unable to create adapter %s", message.data);
+        dmLogError("WebGPU: Unable to create adapter (%d): %.*s", (int)status,
+                   message.data ? (int)message.length : 7, message.data ? message.data : "unknown");
 #else
-        dmLogError("WebGPU: Unable to create adapter %s", message);
+        dmLogError("WebGPU: Unable to create adapter (%d): %s", (int)status, message ? message : "unknown");
 #endif
         context->m_InitComplete = true;
     }
@@ -1455,10 +1479,11 @@ static bool InitializeWebGPUContext(WebGPUContext* context, const ContextParams&
 #endif
 #endif
 
-    // requestAdapter() is allowed to return no adapter and requesting a device
-    // may also fail. Do not continue into limits or feature queries with a
-    // partially initialized context.
-    if (!context->m_Adapter || !context->m_Device)
+    // Every asynchronous initialization stage may fail independently. Do not
+    // initialize backend state unless the adapter, device, queue, and complete
+    // presentation path are all valid.
+    if (!context->m_Adapter || !context->m_Device || !context->m_Queue ||
+        !context->m_Surface || context->m_Format == WGPUTextureFormat_Undefined)
         return false;
 
     context->m_SamplerCache.SetCapacity(32, 64);
@@ -2250,11 +2275,17 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
         WGPUBufferDescriptor desc = {};
 #endif
         desc.usage                = buffer->m_Usage;
-        // queue.writeBuffer() requires four-byte writes. Keep the engine-facing
-        // size exact, but leave room for padding when the data ends mid-word.
+        // Keep the engine-facing size exact, but leave room for the aligned
+        // writes required by queue.writeBuffer(). The shadow copy lets partial
+        // writes preserve bytes surrounding an unaligned update.
         desc.size                 = DM_ALIGN(size, write_alignment);
         buffer->m_Buffer          = wgpuDeviceCreateBuffer(context->m_Device, &desc);
         buffer->m_Used = buffer->m_Base.m_Size = size;
+
+        if (buffer->m_ShadowData.Capacity() < desc.size)
+            buffer->m_ShadowData.SetCapacity(desc.size);
+        buffer->m_ShadowData.SetSize(desc.size);
+        memset(buffer->m_ShadowData.Begin(), 0, desc.size);
     }
     else if (buffer->m_LastRenderPass && buffer->m_LastRenderPass > context->m_LastSubmittedRenderPass) // flush pipeline
     {
@@ -2265,30 +2296,14 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
     if (!data)
         return;
 
-    if (offset % write_alignment)
-    {
-        dmLogError("WebGPU buffer write offset must be a multiple of four (offset: %zu).", offset);
-        return;
-    }
+    assert(offset + size <= buffer->m_ShadowData.Size());
+    memcpy(buffer->m_ShadowData.Begin() + offset, data, size);
 
-    const size_t aligned_size = size & ~(write_alignment - 1);
-    // Padding is only safe at the logical end of the buffer; an interior
-    // partial-word update would overwrite bytes outside the requested range.
-    if (aligned_size != size && offset + size != buffer->m_Used)
-    {
-        dmLogError("WebGPU buffer sub-data writes must end on a four-byte boundary.");
-        return;
-    }
-
-    if (aligned_size)
-        wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset, data, aligned_size);
-
-    if (aligned_size != size)
-    {
-        uint32_t tail = 0;
-        memcpy(&tail, (const uint8_t*)data + aligned_size, size - aligned_size);
-        wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset + aligned_size, &tail, sizeof(tail));
-    }
+    const size_t aligned_offset = offset & ~(write_alignment - 1);
+    const size_t aligned_end    = DM_ALIGN(offset + size, write_alignment);
+    const size_t aligned_size   = aligned_end - aligned_offset;
+    wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, aligned_offset,
+                         buffer->m_ShadowData.Begin() + aligned_offset, aligned_size);
 }
 
 static HUniformBuffer WebGPUNewUniformBuffer(HContext _context, UniformBufferLayout layout, uint32_t size)

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1945,6 +1945,9 @@ static WGPURenderPassEncoder RenderPassBegin(WebGPUContext* context, uint32_t cl
         }
 
         const bool explicit_clear = clear_flags != 0;
+        const bool initialize_opaque_surface = i == 0 &&
+            context->m_InitializeOpaqueSurface &&
+            context->m_CurrentRenderPass.m_Target == context->m_MainRenderTarget;
         if (explicit_clear && (clear_flags & color_buffer_type))
         {
             colorAttachments[i].loadOp       = WGPULoadOp_Clear;
@@ -1952,6 +1955,19 @@ static WGPURenderPassEncoder RenderPassBegin(WebGPUContext* context, uint32_t cl
             colorAttachments[i].clearValue.g = clear_color[1];
             colorAttachments[i].clearValue.b = clear_color[2];
             colorAttachments[i].clearValue.a = clear_color[3];
+        }
+        else if (initialize_opaque_surface)
+        {
+            // WebGL alpha:false exposes an RGB default framebuffer, so its
+            // destination alpha behaves as one. Initialize the newly acquired
+            // WebGPU surface accordingly before render pipelines mask alpha
+            // writes. This also covers scripts that omit a color clear or only
+            // clear depth/stencil at the start of the frame.
+            colorAttachments[i].loadOp       = WGPULoadOp_Clear;
+            colorAttachments[i].clearValue.r = 0.0;
+            colorAttachments[i].clearValue.g = 0.0;
+            colorAttachments[i].clearValue.b = 0.0;
+            colorAttachments[i].clearValue.a = 1.0;
         }
         else if (explicit_clear)
         {
@@ -2057,6 +2073,8 @@ static void WebGPUBeginRenderPass(WebGPUContext* context, uint32_t clear_flags, 
 
         context->m_CurrentRenderPass.m_Target = context->m_CurrentRenderTarget;
         context->m_CurrentRenderPass.m_Encoder = RenderPassBegin(context, clear_flags, clear_color, clear_depth, clear_stencil);
+        if (context->m_CurrentRenderPass.m_Target == context->m_MainRenderTarget)
+            context->m_InitializeOpaqueSurface = 0;
         context->m_ApplyRenderTargetLoadOps = 0;
 
         context->m_CurrentRenderPass.m_Target->m_Scissor[0] = 0;
@@ -2115,6 +2133,11 @@ static void WebGPUBeginFrame(HContext _context)
         WGPUSurfaceTexture surfaceColorTexture = {};
 #endif
         wgpuSurfaceGetCurrentTexture(context->m_Surface, &surfaceColorTexture);
+        // Each acquired canvas texture begins a new presentation frame. Opaque
+        // HTML5 surfaces need alpha initialized before the first main-target
+        // pass; alphaMode:opaque only affects presentation, not destination-
+        // alpha operations performed while rendering.
+        context->m_InitializeOpaqueSurface = context->m_OpaqueSurface;
 
         WGPUTexture     currentColorTexture = surfaceColorTexture.texture;
         const uint32_t  currentWidth = wgpuTextureGetWidth(currentColorTexture),

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1095,6 +1095,17 @@ static WGPURenderPipeline WebGPUGetOrCreateRenderPipeline(WebGPUContext* context
             write_mask |= WGPUColorWriteMask_Blue;
         if (context->m_CurrentPipelineState.m_WriteColorMask & DM_GRAPHICS_STATE_WRITE_A)
             write_mask |= WGPUColorWriteMask_Alpha;
+
+        // A WebGL context created with alpha:false has no destination alpha
+        // channel. WebGPU surfaces are always RGBA, and alphaMode:"opaque"
+        // only controls how the browser presents that channel. Keep the
+        // backing alpha untouched on opaque HTML5 surfaces as well, both for
+        // WebGL parity and for browsers that do not yet honor opaque canvas
+        // compositing consistently (for example, Mozilla bug 2007510).
+        // Off-screen targets must retain the color mask requested by the
+        // application.
+        if (context->m_OpaqueSurface && context->m_CurrentRenderPass.m_Target == context->m_MainRenderTarget)
+            write_mask &= ~WGPUColorWriteMask_Alpha;
 #if defined(DM_GRAPHICS_WEBGPU2)
         WGPUBlendState blend_state  = WGPU_BLEND_STATE_INIT;
 #else
@@ -1152,9 +1163,10 @@ static void WebGPUConfigure(WebGPUContext* context, uint32_t width, uint32_t hei
         // important because framebuffer alpha must not affect page compositing
         // when transparency is disabled. WebGL uses premultiplied alpha when a
         // transparent context is requested, so use the same mode here.
-        surface_conf.alphaMode = dmPlatform::GetWindowStateParam(context->m_BaseContext.m_Window, WINDOW_STATE_ALPHA_BITS) > 0
-            ? WGPUCompositeAlphaMode_Premultiplied
-            : WGPUCompositeAlphaMode_Opaque;
+        context->m_OpaqueSurface = dmPlatform::GetWindowStateParam(context->m_BaseContext.m_Window, WINDOW_STATE_ALPHA_BITS) == 0;
+        surface_conf.alphaMode = context->m_OpaqueSurface
+            ? WGPUCompositeAlphaMode_Opaque
+            : WGPUCompositeAlphaMode_Premultiplied;
 #endif
         wgpuSurfaceConfigure(context->m_Surface, &surface_conf);
     }
@@ -2051,7 +2063,12 @@ static void WebGPUClear(HContext _context, uint32_t flags, uint8_t red, uint8_t 
     TRACE_CALL;
     WebGPUContext* context = (WebGPUContext*)_context;
     WebGPUEndRenderPass(context);
-    const float clear_color[] = { red / 255.0f, green / 255.0f, blue / 255.0f, alpha / 255.0f };
+    // WebGL alpha:false behaves as an RGB default framebuffer. Initialize the
+    // otherwise real WebGPU surface alpha channel to opaque before suppressing
+    // alpha writes in render pipelines (see the color-target setup above).
+    const bool clear_opaque_surface = context->m_OpaqueSurface && context->m_CurrentRenderTarget == context->m_MainRenderTarget;
+    const uint8_t effective_alpha = clear_opaque_surface ? 255 : alpha;
+    const float clear_color[] = { red / 255.0f, green / 255.0f, blue / 255.0f, effective_alpha / 255.0f };
     WebGPUBeginRenderPass(context, flags, (flags & (dmGraphics::BUFFER_TYPE_COLOR0_BIT | dmGraphics::BUFFER_TYPE_COLOR1_BIT | dmGraphics::BUFFER_TYPE_COLOR2_BIT | dmGraphics::BUFFER_TYPE_COLOR3_BIT)) ? clear_color : 0,
                           (flags & dmGraphics::BUFFER_TYPE_DEPTH_BIT) ? &depth : 0,
                           (flags & dmGraphics::BUFFER_TYPE_STENCIL_BIT) ? &stencil : 0);

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -2275,17 +2275,11 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
         WGPUBufferDescriptor desc = {};
 #endif
         desc.usage                = buffer->m_Usage;
-        // Keep the engine-facing size exact, but leave room for the aligned
-        // writes required by queue.writeBuffer(). The shadow copy lets partial
-        // writes preserve bytes surrounding an unaligned update.
+        // Keep the engine-facing size exact, but leave room for padding when
+        // the data ends mid-word. queue.writeBuffer() requires four-byte writes.
         desc.size                 = DM_ALIGN(size, write_alignment);
         buffer->m_Buffer          = wgpuDeviceCreateBuffer(context->m_Device, &desc);
         buffer->m_Used = buffer->m_Base.m_Size = size;
-
-        if (buffer->m_ShadowData.Capacity() < desc.size)
-            buffer->m_ShadowData.SetCapacity(desc.size);
-        buffer->m_ShadowData.SetSize(desc.size);
-        memset(buffer->m_ShadowData.Begin(), 0, desc.size);
     }
     else if (buffer->m_LastRenderPass && buffer->m_LastRenderPass > context->m_LastSubmittedRenderPass) // flush pipeline
     {
@@ -2296,14 +2290,30 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
     if (!data)
         return;
 
-    assert(offset + size <= buffer->m_ShadowData.Size());
-    memcpy(buffer->m_ShadowData.Begin() + offset, data, size);
+    if (offset % write_alignment)
+    {
+        dmLogError("WebGPU buffer write offset must be a multiple of four (offset: %zu).", offset);
+        return;
+    }
 
-    const size_t aligned_offset = offset & ~(write_alignment - 1);
-    const size_t aligned_end    = DM_ALIGN(offset + size, write_alignment);
-    const size_t aligned_size   = aligned_end - aligned_offset;
-    wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, aligned_offset,
-                         buffer->m_ShadowData.Begin() + aligned_offset, aligned_size);
+    const size_t aligned_size = size & ~(write_alignment - 1);
+    // Padding is only safe at the logical end of the buffer. An interior
+    // partial-word update would overwrite bytes outside the requested range.
+    if (aligned_size != size && offset + size != buffer->m_Used)
+    {
+        dmLogError("WebGPU buffer sub-data writes must end on a four-byte boundary.");
+        return;
+    }
+
+    if (aligned_size)
+        wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset, data, aligned_size);
+
+    if (aligned_size != size)
+    {
+        uint32_t tail = 0;
+        memcpy(&tail, (const uint8_t*)data + aligned_size, size - aligned_size);
+        wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset + aligned_size, &tail, sizeof(tail));
+    }
 }
 
 static HUniformBuffer WebGPUNewUniformBuffer(HContext _context, UniformBufferLayout layout, uint32_t size)

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -1146,6 +1146,16 @@ static void WebGPUConfigure(WebGPUContext* context, uint32_t width, uint32_t hei
         surface_conf.width                    = width;
         surface_conf.height                   = height;
         surface_conf.presentMode              = WGPUPresentMode_Fifo;
+#if defined(__EMSCRIPTEN__)
+        // Match the WebGL canvas policy controlled by
+        // html5.transparent_graphics_context. Explicitly selecting opaque is
+        // important because framebuffer alpha must not affect page compositing
+        // when transparency is disabled. WebGL uses premultiplied alpha when a
+        // transparent context is requested, so use the same mode here.
+        surface_conf.alphaMode = dmPlatform::GetWindowStateParam(context->m_BaseContext.m_Window, WINDOW_STATE_ALPHA_BITS) > 0
+            ? WGPUCompositeAlphaMode_Premultiplied
+            : WGPUCompositeAlphaMode_Opaque;
+#endif
         wgpuSurfaceConfigure(context->m_Surface, &surface_conf);
     }
 
@@ -1339,6 +1349,8 @@ static void instanceRequestAdapterCallback(WGPURequestAdapterStatus status, WGPU
         descriptor.requiredFeatures = features;
         if (wgpuAdapterHasFeature(context->m_Adapter, WGPUFeatureName_TextureCompressionBC))
             features[descriptor.requiredFeatureCount++] = WGPUFeatureName_TextureCompressionBC;
+        if (wgpuAdapterHasFeature(context->m_Adapter, WGPUFeatureName_TextureCompressionETC2))
+            features[descriptor.requiredFeatureCount++] = WGPUFeatureName_TextureCompressionETC2;
         if (wgpuAdapterHasFeature(context->m_Adapter, WGPUFeatureName_TextureCompressionASTC))
             features[descriptor.requiredFeatureCount++] = WGPUFeatureName_TextureCompressionASTC;
         if (wgpuAdapterHasFeature(context->m_Adapter, WGPUFeatureName_Float32Filterable))
@@ -1402,6 +1414,11 @@ static bool InitializeWebGPUContext(WebGPUContext* context, const ContextParams&
     dmLogInfo("WebGPU v%d", webgpu_version);
 
     context->m_Instance = wgpuCreateInstance(nullptr);
+    if (!context->m_Instance)
+    {
+        dmLogError("WebGPU: Unable to create instance");
+        return false;
+    }
 
 #if defined(DM_GRAPHICS_WEBGPU2)
     WGPURequestAdapterCallbackInfo requestAdapterCallbackInfo = WGPU_REQUEST_ADAPTER_CALLBACK_INFO_INIT;
@@ -1425,6 +1442,13 @@ static bool InitializeWebGPUContext(WebGPUContext* context, const ContextParams&
         emscripten_sleep(100);
 #endif
 #endif
+
+    // requestAdapter() is allowed to return no adapter and requesting a device
+    // may also fail. Do not continue into limits or feature queries with a
+    // partially initialized context.
+    if (!context->m_Adapter || !context->m_Device)
+        return false;
+
     context->m_SamplerCache.SetCapacity(32, 64);
     context->m_BindGroupCache.SetCapacity(32, 64);
     context->m_RenderPipelineCache.SetCapacity(32, 64);

--- a/engine/graphics/src/webgpu/graphics_webgpu.cpp
+++ b/engine/graphics/src/webgpu/graphics_webgpu.cpp
@@ -2200,6 +2200,7 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
 {
     TRACE_CALL;
     assert(size);
+    const size_t write_alignment = 4;
     if (!buffer->m_Buffer) // create it
     {
 #if defined(DM_GRAPHICS_WEBGPU2)
@@ -2208,16 +2209,45 @@ static void WebGPUWriteBuffer(WebGPUContext* context, WebGPUBuffer* buffer, size
         WGPUBufferDescriptor desc = {};
 #endif
         desc.usage                = buffer->m_Usage;
-        desc.size                 = size;
+        // queue.writeBuffer() requires four-byte writes. Keep the engine-facing
+        // size exact, but leave room for padding when the data ends mid-word.
+        desc.size                 = DM_ALIGN(size, write_alignment);
         buffer->m_Buffer          = wgpuDeviceCreateBuffer(context->m_Device, &desc);
-        buffer->m_Used = buffer->m_Base.m_Size = desc.size;
+        buffer->m_Used = buffer->m_Base.m_Size = size;
     }
     else if (buffer->m_LastRenderPass && buffer->m_LastRenderPass > context->m_LastSubmittedRenderPass) // flush pipeline
     {
         //dmLogWarning("Deoptimization: Forcing pipeline flush due to buffer write");
         WebGPUSubmitCommandEncoder(context);
     }
-    wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset, data, size);
+
+    if (!data)
+        return;
+
+    if (offset % write_alignment)
+    {
+        dmLogError("WebGPU buffer write offset must be a multiple of four (offset: %zu).", offset);
+        return;
+    }
+
+    const size_t aligned_size = size & ~(write_alignment - 1);
+    // Padding is only safe at the logical end of the buffer; an interior
+    // partial-word update would overwrite bytes outside the requested range.
+    if (aligned_size != size && offset + size != buffer->m_Used)
+    {
+        dmLogError("WebGPU buffer sub-data writes must end on a four-byte boundary.");
+        return;
+    }
+
+    if (aligned_size)
+        wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset, data, aligned_size);
+
+    if (aligned_size != size)
+    {
+        uint32_t tail = 0;
+        memcpy(&tail, (const uint8_t*)data + aligned_size, size - aligned_size);
+        wgpuQueueWriteBuffer(context->m_Queue, buffer->m_Buffer, offset + aligned_size, &tail, sizeof(tail));
+    }
 }
 
 static HUniformBuffer WebGPUNewUniformBuffer(HContext _context, UniformBufferLayout layout, uint32_t size)

--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -248,6 +248,7 @@ namespace dmGraphics
         uint32_t            m_HasValidationError : 1;
         uint32_t            m_InitComplete : 1;
         uint32_t            m_OpaqueSurface : 1;
+        uint32_t            m_InitializeOpaqueSurface : 1;
 
         // StorageBufferBinding             m_CurrentStorageBuffers[MAX_STORAGE_BUFFERS];
     };

--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -247,6 +247,7 @@ namespace dmGraphics
         uint32_t            m_ApplyRenderTargetLoadOps : 1;
         uint32_t            m_HasValidationError : 1;
         uint32_t            m_InitComplete : 1;
+        uint32_t            m_OpaqueSurface : 1;
 
         // StorageBufferBinding             m_CurrentStorageBuffers[MAX_STORAGE_BUFFERS];
     };

--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -47,6 +47,7 @@ namespace dmGraphics
 #endif
 
         WGPUBuffer                 m_Buffer = NULL;
+        dmArray<uint8_t>           m_ShadowData;
         size_t                     m_Used = 0;
         size_t                     m_LastRenderPass = 0;
     };

--- a/engine/graphics/src/webgpu/graphics_webgpu_private.h
+++ b/engine/graphics/src/webgpu/graphics_webgpu_private.h
@@ -47,7 +47,6 @@ namespace dmGraphics
 #endif
 
         WGPUBuffer                 m_Buffer = NULL;
-        dmArray<uint8_t>           m_ShadowData;
         size_t                     m_Used = 0;
         size_t                     m_LastRenderPass = 0;
     };

--- a/engine/platform/src/platform_window_glfw.cpp
+++ b/engine/platform/src/platform_window_glfw.cpp
@@ -266,7 +266,7 @@ namespace dmPlatform
 
         int mode = params.m_Fullscreen ? GLFW_FULLSCREEN : GLFW_WINDOW;
 
-        if (!glfwOpenWindow(params.m_Width, params.m_Height, 8, 8, 8, 8, 32, 8, mode))
+        if (!glfwOpenWindow(params.m_Width, params.m_Height, 8, 8, 8, params.m_ContextAlphabits, 32, 8, mode))
         {
             return WINDOW_RESULT_WINDOW_OPEN_ERROR;
         }

--- a/engine/shaderc/src/shaderc_spvc.cpp
+++ b/engine/shaderc/src/shaderc_spvc.cpp
@@ -485,6 +485,30 @@ namespace dmShaderc
         }
     }
 
+    static void SetCombinedSamplerNamesGLSL(HShaderContext context, ShaderCompilerSPVC* compiler)
+    {
+        dmArray<CombinedSampler> combined_samplers;
+        GetCombinedSamplerMapSPIRV(context, compiler, combined_samplers);
+
+        dmArray<char> combined_name;
+        const char* prefix = "SPIRV_Cross_Combined";
+        for (uint32_t i = 0; i < combined_samplers.Size(); ++i)
+        {
+            const CombinedSampler& sampler = combined_samplers[i];
+            const char* image_name         = sampler.m_ImageName;
+            const char* sampler_name       = sampler.m_SamplerName;
+            if (!image_name || !image_name[0] || !sampler_name || !sampler_name[0])
+                continue;
+
+            const size_t combined_name_size = strlen(prefix) + strlen(image_name) + strlen(sampler_name) + 1;
+            if (combined_name.Capacity() < combined_name_size)
+                combined_name.SetCapacity(combined_name_size);
+            combined_name.SetSize(combined_name_size);
+            dmSnPrintf(combined_name.Begin(), combined_name_size, "%s%s%s", prefix, image_name, sampler_name);
+            spvc_compiler_set_name(compiler->m_SPVCCompiler, sampler.m_CombinedId, combined_name.Begin());
+        }
+    }
+
     #define MAX_BINDINGS 128
     bool GetFirstFreeBindingIndex(HShaderContext context, uint32_t* binding)
     {
@@ -655,6 +679,13 @@ namespace dmShaderc
 
         spvc_compiler_set_entry_point(compiler->m_SPVCCompiler, options.m_EntryPoint, context->m_ExecutionModel);
         spvc_compiler_build_combined_image_samplers(compiler->m_SPVCCompiler);
+
+        // SPIRV-Cross may leave synthetic combined samplers with an ID-based
+        // name (for example, `_194`) after texture/sampler splitting. Give the
+        // generated resource its canonical SPIRV-Cross name so Bob can map it
+        // back to the reflected texture name in GLSL variants.
+        if (compiler->m_BaseCompiler.m_Language == SHADER_LANGUAGE_GLSL)
+            SetCombinedSamplerNamesGLSL(context, compiler);
 
         if (compiler->m_BaseCompiler.m_Language == SHADER_LANGUAGE_GLSL)
         {


### PR DESCRIPTION
#### Technical changes

* Adds asynchronous WebGPU adapter probing before engine startup, enabling reliable WebGL fallback.
* Hardens WebGPU initialization by validating instance, adapter, device, queue, surface, and format creation.
* Enables ETC2 texture compression when supported by the adapter.
* Aligns WebGPU buffer uploads to four bytes while preserving partial updates through CPU shadow buffers.
* Matches WebGL canvas transparency behavior through explicit WebGPU alpha modes and opaque framebuffer handling.
* Fixes combined sampler naming in dual WebGL/WebGPU shader bundles by reusing the SPIR-V sampler mapping.
* Adds regression coverage for WebGL sampler names in dual-adapter bundles.