### PR TITLE
Fix crash when using a tilemap when 2D physics is excluded

### DIFF
--- a/engine/gamesys/src/gamesys/resources/res_tilegrid.cpp
+++ b/engine/gamesys/src/gamesys/resources/res_tilegrid.cpp
@@ -90,7 +90,7 @@ namespace dmGameSystem
 
         dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
         dmPhysics::HHullSet2D hull_set = (dmPhysics::HHullSet2D)texture_set->m_HullSet;
-        if (hull_set != 0x0)
+        if (context != 0x0 && hull_set != 0x0)
         {
             // Calculate AABB for offset
             dmVMath::Point3 offset(0.0f, 0.0f, 0.0f);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -446,6 +446,23 @@ class LightResourceTest : public ResourceTest { public: LightResourceTest() { Se
 class ResourceFolderTest : public ResourceTest { public: ResourceFolderTest() { SetContentFolder("resource"); } };
 class GuiResourceTest : public ResourceTest { public: GuiResourceTest() { SetContentFolder("gui"); } };
 class MaterialResourceTest : public ResourceTest { public: MaterialResourceTest() { SetContentFolder("material"); } };
+class TileGrid3DResourceTest : public ResourceTest
+{
+public:
+    TileGrid3DResourceTest()
+    {
+        SetContentFolder("tile");
+        m_projectOptions.m_3D = true;
+    }
+};
+
+TEST_F(TileGrid3DResourceTest, LoadTileGrid)
+{
+    void* resource = 0;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/tile/valid.tilemapc", &resource));
+    ASSERT_NE((void*) 0, resource);
+    dmResource::Release(m_Factory, resource);
+}
 
 TEST_F(TextureSetResourceTest, TestReloadTextureSet)
 {


### PR DESCRIPTION
This fixes an issue where the engine would crash if using a tilemap in a game where 2D physics is excluded.

Fixes #13020 