### PR TITLE
Improve using go.get/go.set together with matrix types in custom vertex formats

### DIFF
--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -349,7 +349,7 @@ namespace dmGameSystem
                 if (dynamic_attribute_index >= 0)
                 {
                     component_info.m_ValuePtr        = (uint8_t*) &dynamic_info.m_Infos[dynamic_attribute_index].m_Values;
-                    component_info.m_ValueVectorType = dmGraphics::VertexAttribute::VECTOR_TYPE_VEC4;
+                    component_info.m_ValueVectorType = component_info.m_VectorType;
                     component_info.m_DataType        = dmGraphics::VertexAttribute::TYPE_FLOAT;
                     continue;
                 }
@@ -528,6 +528,12 @@ namespace dmGameSystem
                 case 2: return dmGameObject::PropertyVar(dmVMath::Vector3(values[0], values[1], 0.0f));
                 case 3: return dmGameObject::PropertyVar(dmVMath::Vector3(values[0], values[1], values[2]));
                 case 4: return dmGameObject::PropertyVar(dmVMath::Vector4(values[0], values[1], values[2], values[3]));
+                case 16:
+                {
+                    dmVMath::Matrix4 value;
+                    memcpy(&value, values, sizeof(value));
+                    return dmGameObject::PropertyVar(value);
+                }
             }
         }
 
@@ -580,7 +586,7 @@ namespace dmGameSystem
             dmGraphics::GetAttributeValues(*comp_attribute, &info.m_ValuePtr, &value_byte_size);
         }
 
-        float values[4];
+        float values[16] = {};
         // Use info.m_ValuePtr so we use the component's value when the callback returned true, otherwise the material's default.
         VertexAttributeInfoToFloats(info.m_Attribute, info.m_ValuePtr, values);
         out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(values, info.m_Attribute->m_ElementCount, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
@@ -600,7 +606,8 @@ namespace dmGameSystem
     {
         if (var.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER &&
             var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR3 &&
-            var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR4)
+            var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR4 &&
+            var.m_Type != dmGameObject::PROPERTY_TYPE_MATRIX4)
         {
             return dmGameObject::PROPERTY_RESULT_UNSUPPORTED_TYPE;
         }
@@ -695,6 +702,11 @@ namespace dmGameSystem
         else if (var.m_Type == dmGameObject::PROPERTY_TYPE_NUMBER)
         {
             values[0] = var.m_Number;
+        }
+        // go.set("#model", "attribute_mat4", vmath.matrix4())
+        else if (var.m_Type == dmGameObject::PROPERTY_TYPE_MATRIX4)
+        {
+            memcpy(values, var.m_M4, sizeof(var.m_M4));
         }
         // go.set("#sprite", "attribute_vec", vmath.vector4(0.0, 1.0, 2.0, 3.0))
         else

--- a/engine/gamesys/src/gamesys/gamesys_private.cpp
+++ b/engine/gamesys/src/gamesys/gamesys_private.cpp
@@ -514,7 +514,52 @@ namespace dmGameSystem
         return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
     }
 
-    static dmGameObject::PropertyVar DynamicAttributeValuesToPropertyVar(float* values, uint32_t element_count, uint32_t element_index, bool use_element_index)
+    static bool IsMatrixAttribute(dmGraphics::VertexAttribute::VectorType vector_type)
+    {
+        return vector_type == dmGraphics::VertexAttribute::VECTOR_TYPE_MAT2 ||
+               vector_type == dmGraphics::VertexAttribute::VECTOR_TYPE_MAT3 ||
+               vector_type == dmGraphics::VertexAttribute::VECTOR_TYPE_MAT4;
+    }
+
+    static uint32_t GetMatrixDimension(dmGraphics::VertexAttribute::VectorType vector_type)
+    {
+        switch (vector_type)
+        {
+            case dmGraphics::VertexAttribute::VECTOR_TYPE_MAT2: return 2;
+            case dmGraphics::VertexAttribute::VECTOR_TYPE_MAT3: return 3;
+            case dmGraphics::VertexAttribute::VECTOR_TYPE_MAT4: return 4;
+            default: break;
+        }
+        return 0;
+    }
+
+    static dmVMath::Matrix4 MatrixAttributeValuesToMatrix4(const float* values, dmGraphics::VertexAttribute::VectorType vector_type)
+    {
+        dmVMath::Matrix4 matrix = dmVMath::Matrix4::identity();
+        const uint32_t dimension = GetMatrixDimension(vector_type);
+        for (uint32_t column = 0; column < dimension; ++column)
+        {
+            for (uint32_t row = 0; row < dimension; ++row)
+            {
+                matrix[column][row] = values[column * dimension + row];
+            }
+        }
+        return matrix;
+    }
+
+    static void Matrix4ToMatrixAttributeValues(const float* matrix, dmGraphics::VertexAttribute::VectorType vector_type, float* values)
+    {
+        const uint32_t dimension = GetMatrixDimension(vector_type);
+        for (uint32_t column = 0; column < dimension; ++column)
+        {
+            for (uint32_t row = 0; row < dimension; ++row)
+            {
+                values[column * dimension + row] = matrix[column * 4 + row];
+            }
+        }
+    }
+
+    static dmGameObject::PropertyVar DynamicAttributeValuesToPropertyVar(const float* values, dmGraphics::VertexAttribute::VectorType vector_type, uint32_t element_index, bool use_element_index)
     {
         if (use_element_index)
         {
@@ -522,18 +567,15 @@ namespace dmGameSystem
         }
         else
         {
-            switch(element_count)
+            switch(vector_type)
             {
-                case 1: return dmGameObject::PropertyVar(values[0]);
-                case 2: return dmGameObject::PropertyVar(dmVMath::Vector3(values[0], values[1], 0.0f));
-                case 3: return dmGameObject::PropertyVar(dmVMath::Vector3(values[0], values[1], values[2]));
-                case 4: return dmGameObject::PropertyVar(dmVMath::Vector4(values[0], values[1], values[2], values[3]));
-                case 16:
-                {
-                    dmVMath::Matrix4 value;
-                    memcpy(&value, values, sizeof(value));
-                    return dmGameObject::PropertyVar(value);
-                }
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_SCALAR: return dmGameObject::PropertyVar(values[0]);
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_VEC2:   return dmGameObject::PropertyVar(dmVMath::Vector3(values[0], values[1], 0.0f));
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_VEC3:   return dmGameObject::PropertyVar(dmVMath::Vector3(values[0], values[1], values[2]));
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_VEC4:   return dmGameObject::PropertyVar(dmVMath::Vector4(values[0], values[1], values[2], values[3]));
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_MAT2:
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_MAT3:
+                case dmGraphics::VertexAttribute::VECTOR_TYPE_MAT4:   return dmGameObject::PropertyVar(MatrixAttributeValuesToMatrix4(values, vector_type));
             }
         }
 
@@ -569,7 +611,7 @@ namespace dmGameSystem
 
             if (dynamic_info_index >= 0)
             {
-                out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(dynamic_info.m_Infos[dynamic_info_index].m_Values, info.m_Attribute->m_ElementCount, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
+                out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(dynamic_info.m_Infos[dynamic_info_index].m_Values, info.m_Attribute->m_VectorType, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
                 return dmGameObject::PROPERTY_RESULT_OK;
             }
         }
@@ -580,16 +622,27 @@ namespace dmGameSystem
 
         // If this callback returns false, e.g a component resource might not have a value override for the attribute,
         // we fallback to the material attribute data instead
-        if (callback(callback_user_data, info.m_AttributeNameHash, &comp_attribute))
+        const bool has_component_attribute = callback(callback_user_data, info.m_AttributeNameHash, &comp_attribute);
+        if (has_component_attribute)
         {
             uint32_t value_byte_size;
             dmGraphics::GetAttributeValues(*comp_attribute, &info.m_ValuePtr, &value_byte_size);
         }
 
         float values[16] = {};
-        // Use info.m_ValuePtr so we use the component's value when the callback returned true, otherwise the material's default.
-        VertexAttributeInfoToFloats(info.m_Attribute, info.m_ValuePtr, values);
-        out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(values, info.m_Attribute->m_ElementCount, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
+        if (has_component_attribute && IsMatrixAttribute(info.m_Attribute->m_VectorType) && IsMatrixAttribute(comp_attribute->m_VectorType))
+        {
+            float component_values[16] = {};
+            VertexAttributeToFloats(comp_attribute, info.m_ValuePtr, component_values);
+            dmVMath::Matrix4 component_matrix = MatrixAttributeValuesToMatrix4(component_values, comp_attribute->m_VectorType);
+            Matrix4ToMatrixAttributeValues(&component_matrix[0][0], info.m_Attribute->m_VectorType, values);
+        }
+        else
+        {
+            // Use info.m_ValuePtr so we use the component's value when the callback returned true, otherwise the material's default.
+            VertexAttributeInfoToFloats(info.m_Attribute, info.m_ValuePtr, values);
+        }
+        out_desc.m_Variant = DynamicAttributeValuesToPropertyVar(values, info.m_Attribute->m_VectorType, info.m_ElementIndex, info.m_AttributeNameHash != name_hash);
 
         return dmGameObject::PROPERTY_RESULT_OK;
     }
@@ -604,18 +657,22 @@ namespace dmGameSystem
         void*                               callback_user_data,
         const dmGraphics::VertexAttributeInfo** attribute_out)
     {
-        if (var.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER &&
-            var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR3 &&
-            var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR4 &&
-            var.m_Type != dmGameObject::PROPERTY_TYPE_MATRIX4)
-        {
-            return dmGameObject::PROPERTY_RESULT_UNSUPPORTED_TYPE;
-        }
-
         dmRender::MaterialProgramAttributeInfo info;
         if (!dmRender::GetMaterialProgramAttributeInfo(material, name_hash, info))
         {
             return dmGameObject::PROPERTY_RESULT_NOT_FOUND;
+        }
+
+        const bool set_element = info.m_AttributeNameHash != name_hash;
+        const bool matrix_attribute = IsMatrixAttribute(info.m_Attribute->m_VectorType);
+        if ((matrix_attribute && (set_element || var.m_Type != dmGameObject::PROPERTY_TYPE_MATRIX4)) ||
+            (!matrix_attribute && set_element && var.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER) ||
+            (!matrix_attribute && !set_element &&
+                var.m_Type != dmGameObject::PROPERTY_TYPE_NUMBER &&
+                var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR3 &&
+                var.m_Type != dmGameObject::PROPERTY_TYPE_VECTOR4))
+        {
+            return dmGameObject::PROPERTY_RESULT_UNSUPPORTED_TYPE;
         }
 
         DynamicAttributeInfo* dynamic_info = 0;
@@ -682,19 +739,30 @@ namespace dmGameSystem
 
             const dmGraphics::VertexAttribute* comp_attribute;
             // The component might have a value override for the attribute
-            if (callback(callback_user_data, info.m_AttributeNameHash, &comp_attribute))
+            const bool has_component_attribute = callback(callback_user_data, info.m_AttributeNameHash, &comp_attribute);
+            if (has_component_attribute)
             {
                 uint32_t value_byte_size;
                 dmGraphics::GetAttributeValues(*comp_attribute, &info.m_ValuePtr, &value_byte_size);
             }
 
             // Then, we need to convert each element of the attribute data to a float, since that is the backing storage for the override.
-            // Use info.m_ValuePtr so we use the component's value when the callback returned true, otherwise the material's default.
-            VertexAttributeInfoToFloats(info.m_Attribute, info.m_ValuePtr, values);
+            if (has_component_attribute && matrix_attribute && IsMatrixAttribute(comp_attribute->m_VectorType))
+            {
+                float component_values[16] = {};
+                VertexAttributeToFloats(comp_attribute, info.m_ValuePtr, component_values);
+                dmVMath::Matrix4 component_matrix = MatrixAttributeValuesToMatrix4(component_values, comp_attribute->m_VectorType);
+                Matrix4ToMatrixAttributeValues(&component_matrix[0][0], info.m_Attribute->m_VectorType, values);
+            }
+            else
+            {
+                // Use info.m_ValuePtr so we use the component's value when the callback returned true, otherwise the material's default.
+                VertexAttributeInfoToFloats(info.m_Attribute, info.m_ValuePtr, values);
+            }
         }
 
         // go.set("#sprite", "attribute_vec.x", 10.0)
-        if (info.m_AttributeNameHash != name_hash)
+        if (set_element)
         {
             values[info.m_ElementIndex] = var.m_Number;
         }
@@ -703,10 +771,10 @@ namespace dmGameSystem
         {
             values[0] = var.m_Number;
         }
-        // go.set("#model", "attribute_mat4", vmath.matrix4())
-        else if (var.m_Type == dmGameObject::PROPERTY_TYPE_MATRIX4)
+        // Matrix attributes use matrix4 properties. Smaller matrices take the top-left portion.
+        else if (matrix_attribute)
         {
-            memcpy(values, var.m_M4, sizeof(var.m_M4));
+            Matrix4ToMatrixAttributeValues(var.m_M4, info.m_Attribute->m_VectorType, values);
         }
         // go.set("#sprite", "attribute_vec", vmath.vector4(0.0, 1.0, 2.0, 3.0))
         else

--- a/engine/gamesys/src/gamesys/gamesys_private.h
+++ b/engine/gamesys/src/gamesys/gamesys_private.h
@@ -135,7 +135,7 @@ namespace dmGameSystem
         struct Info
         {
             dmhash_t m_NameHash;
-            float    m_Values[4]; // Enough to store a float vec4 property (no support for mat4 yet)
+            float    m_Values[16]; // Enough to store a float mat4 property
         };
 
         Info*   m_Infos;

--- a/engine/gamesys/src/gamesys/test/material/build.inputs
+++ b/engine/gamesys/src/gamesys/test/material/build.inputs
@@ -15,6 +15,7 @@
 /material/light_buffer.material
 /material/light_buffer_small.material
 /material/local_vertexspace.material
+/material/matrix_attributes.material
 /material/material.go
 /material/material_constant_array.material
 /material/material_constant_array_v140.material

--- a/engine/gamesys/src/gamesys/test/material/matrix_attributes.fp
+++ b/engine/gamesys/src/gamesys/test/material/matrix_attributes.fp
@@ -1,0 +1,8 @@
+#version 140
+
+out vec4 out_fragColor;
+
+void main()
+{
+    out_fragColor = vec4(1.0);
+}

--- a/engine/gamesys/src/gamesys/test/material/matrix_attributes.material
+++ b/engine/gamesys/src/gamesys/test/material/matrix_attributes.material
@@ -1,0 +1,28 @@
+name: "matrix_attributes"
+vertex_program: "/material/matrix_attributes.vp"
+fragment_program: "/material/matrix_attributes.fp"
+attributes {
+  name: "custom_mat3"
+  vector_type: VECTOR_TYPE_MAT3
+  double_values {
+    v: 1.0
+    v: 2.0
+    v: 3.0
+    v: 4.0
+    v: 5.0
+    v: 6.0
+    v: 7.0
+    v: 8.0
+    v: 9.0
+  }
+}
+attributes {
+  name: "custom_mat2"
+  vector_type: VECTOR_TYPE_MAT2
+  double_values {
+    v: 10.0
+    v: 11.0
+    v: 12.0
+    v: 13.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/material/matrix_attributes.vp
+++ b/engine/gamesys/src/gamesys/test/material/matrix_attributes.vp
@@ -1,0 +1,11 @@
+#version 140
+
+in vec4 position;
+in mat3 custom_mat3;
+in mat2 custom_mat2;
+
+void main()
+{
+    vec2 position2 = custom_mat2 * position.xy;
+    gl_Position = vec4(custom_mat3 * vec3(position2, position.z), 1.0);
+}

--- a/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.material
+++ b/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.material
@@ -12,3 +12,25 @@ attributes {
     v: 1.0
   }
 }
+attributes {
+  name: "custom_transform"
+  vector_type: VECTOR_TYPE_MAT4
+  double_values {
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.material
+++ b/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.material
@@ -34,3 +34,28 @@ attributes {
     v: 1.0
   }
 }
+attributes {
+  name: "custom_mat3"
+  vector_type: VECTOR_TYPE_MAT3
+  double_values {
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+  }
+}
+attributes {
+  name: "custom_mat2"
+  vector_type: VECTOR_TYPE_MAT2
+  double_values {
+    v: 1.0
+    v: 0.0
+    v: 0.0
+    v: 1.0
+  }
+}

--- a/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.script
+++ b/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.script
@@ -18,10 +18,25 @@ local function assert_custom_color(v)
     assert_vec4(v, go.get("#model", "custom_color"))
 end
 
+local function matrix4(...)
+    local values = {...}
+    local matrix = vmath.matrix4()
+    matrix.c0 = vmath.vector4(unpack(values, 1, 4))
+    matrix.c1 = vmath.vector4(unpack(values, 5, 8))
+    matrix.c2 = vmath.vector4(unpack(values, 9, 12))
+    matrix.c3 = vmath.vector4(unpack(values, 13, 16))
+    return matrix
+end
+
 local function test_go_get()
     assert_custom_color(vmath.vector4(1,0,0,1))
     go.set("#model", "custom_color", vmath.vector4(0,1,0,1))
     assert_custom_color(vmath.vector4(0,1,0,1))
+
+    assert_mat4(vmath.matrix4(), go.get("#model", "custom_transform"))
+    local custom_transform = matrix4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    go.set("#model", "custom_transform", custom_transform)
+    assert_mat4(custom_transform, go.get("#model", "custom_transform"))
 end
 
 function init(self)

--- a/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.script
+++ b/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.script
@@ -28,6 +28,21 @@ local function matrix4(...)
     return matrix
 end
 
+local function matrix3_as_matrix4(matrix)
+    local result = vmath.matrix4()
+    result.c0 = vmath.vector4(matrix.c0.x, matrix.c0.y, matrix.c0.z, 0)
+    result.c1 = vmath.vector4(matrix.c1.x, matrix.c1.y, matrix.c1.z, 0)
+    result.c2 = vmath.vector4(matrix.c2.x, matrix.c2.y, matrix.c2.z, 0)
+    return result
+end
+
+local function matrix2_as_matrix4(matrix)
+    local result = vmath.matrix4()
+    result.c0 = vmath.vector4(matrix.c0.x, matrix.c0.y, 0, 0)
+    result.c1 = vmath.vector4(matrix.c1.x, matrix.c1.y, 0, 0)
+    return result
+end
+
 local function test_go_get()
     assert_custom_color(vmath.vector4(1,0,0,1))
     go.set("#model", "custom_color", vmath.vector4(0,1,0,1))
@@ -37,6 +52,15 @@ local function test_go_get()
     local custom_transform = matrix4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
     go.set("#model", "custom_transform", custom_transform)
     assert_mat4(custom_transform, go.get("#model", "custom_transform"))
+
+    assert_mat4(vmath.matrix4(), go.get("#model", "custom_mat3"))
+    go.set("#model", "custom_mat3", custom_transform)
+    assert_mat4(matrix3_as_matrix4(custom_transform), go.get("#model", "custom_mat3"))
+
+    assert_mat4(vmath.matrix4(), go.get("#model", "custom_mat2"))
+    assert_error(function() go.set("#model", "custom_mat2", vmath.vector4(1, 2, 3, 4)) end)
+    go.set("#model", "custom_mat2", custom_transform)
+    assert_mat4(matrix2_as_matrix4(custom_transform), go.get("#model", "custom_mat2"))
 end
 
 function init(self)

--- a/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.vp
+++ b/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.vp
@@ -3,12 +3,16 @@
 in highp vec4 position;
 in highp vec4 custom_color;
 in highp mat4 custom_transform;
+in highp mat3 custom_mat3;
+in highp mat2 custom_mat2;
 
 out mediump vec4 var_color;
 
 void main()
 {
-    gl_Position = custom_transform * vec4(position.xyz, 1.0);
+    vec2 position2 = custom_mat2 * position.xy;
+    vec3 position3 = custom_mat3 * vec3(position2, position.z);
+    gl_Position = custom_transform * vec4(position3, 1.0);
     var_color = custom_color;
 }
 

--- a/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.vp
+++ b/engine/gamesys/src/gamesys/test/model/dynamic_vertex_attributes.vp
@@ -2,12 +2,13 @@
 
 in highp vec4 position;
 in highp vec4 custom_color;
+in highp mat4 custom_transform;
 
 out mediump vec4 var_color;
 
 void main()
 {
-    gl_Position = vec4(position.xyz, 1.0);
+    gl_Position = custom_transform * vec4(position.xyz, 1.0);
     var_color = custom_color;
 }
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -11355,13 +11355,15 @@ TEST_F(ModelTest, DynamicVertexAttributes)
     dmGraphics::HVertexDeclaration inst_decl;
     dmGameSystem::GetModelComponentAttributeRenderData(component, 0, &vx_buffer, &vx_decl, &inst_decl);
 
-    ASSERT_EQ(1, vx_decl->m_StreamCount);
+    ASSERT_EQ(2, vx_decl->m_StreamCount);
     ASSERT_EQ(dmHashString64("custom_color"), vx_decl->m_Streams[0].m_NameHash);
+    ASSERT_EQ(dmHashString64("custom_transform"), vx_decl->m_Streams[1].m_NameHash);
 
     // Note: The vertex buffer contains only the custom data, not the position stream!
     struct vx_format
     {
         dmVMath::Vector4 custom_color;
+        dmVMath::Matrix4 custom_transform;
     };
 
     // Should be a cube with 24 vertices
@@ -11373,10 +11375,19 @@ TEST_F(ModelTest, DynamicVertexAttributes)
 
     // This should be the last value that the script "dynamic_vertex_attributes.script" sets
     dmVMath::Vector4 exp = dmVMath::Vector4(0.0f, 1.0f, 0.0f, 1.0f);
+    dmVMath::Matrix4 exp_transform(
+        dmVMath::Vector4(1.0f, 2.0f, 3.0f, 4.0f),
+        dmVMath::Vector4(5.0f, 6.0f, 7.0f, 8.0f),
+        dmVMath::Vector4(9.0f, 10.0f, 11.0f, 12.0f),
+        dmVMath::Vector4(13.0f, 14.0f, 15.0f, 16.0f));
 
     for (int i = 0; i < exp_num_vertices; ++i)
     {
         ASSERT_VEC4(exp, vx_data[i].custom_color);
+        ASSERT_VEC4(exp_transform[0], vx_data[i].custom_transform[0]);
+        ASSERT_VEC4(exp_transform[1], vx_data[i].custom_transform[1]);
+        ASSERT_VEC4(exp_transform[2], vx_data[i].custom_transform[2]);
+        ASSERT_VEC4(exp_transform[3], vx_data[i].custom_transform[3]);
     }
 
     dmGraphics::UnmapVertexBuffer(m_GraphicsContext, vx_buffer);

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -11444,46 +11444,52 @@ TEST_F(ModelTest, DynamicVertexAttributes)
     ASSERT_EQ(dmHashString64("custom_mat3"), vx_decl->m_Streams[2].m_NameHash);
     ASSERT_EQ(dmHashString64("custom_mat2"), vx_decl->m_Streams[3].m_NameHash);
 
-    // Note: The vertex buffer contains only the custom data, not the position stream!
-    struct vx_format
-    {
-        dmVMath::Vector4 custom_color;
-        dmVMath::Matrix4 custom_transform;
-        float custom_mat3[9];
-        float custom_mat2[4];
-    };
-
     // Should be a cube with 24 vertices
     uint32_t exp_num_vertices = 24;
+    uint32_t vertex_stride = dmGraphics::GetVertexDeclarationStride(vx_decl);
     uint32_t vx_buffer_size = dmGraphics::GetVertexBufferSize(vx_buffer);
-    ASSERT_EQ(exp_num_vertices, vx_buffer_size / sizeof(vx_format));
+    ASSERT_EQ(exp_num_vertices, vx_buffer_size / vertex_stride);
 
-    vx_format* vx_data = (vx_format*) dmGraphics::MapVertexBuffer(m_GraphicsContext, vx_buffer, dmGraphics::BUFFER_ACCESS_READ_ONLY);
+    uint32_t color_offset = dmGraphics::GetVertexStreamOffset(vx_decl, dmHashString64("custom_color"));
+    uint32_t transform_offset = dmGraphics::GetVertexStreamOffset(vx_decl, dmHashString64("custom_transform"));
+    uint32_t mat3_offset = dmGraphics::GetVertexStreamOffset(vx_decl, dmHashString64("custom_mat3"));
+    uint32_t mat2_offset = dmGraphics::GetVertexStreamOffset(vx_decl, dmHashString64("custom_mat2"));
+    ASSERT_NE(dmGraphics::INVALID_STREAM_OFFSET, color_offset);
+    ASSERT_NE(dmGraphics::INVALID_STREAM_OFFSET, transform_offset);
+    ASSERT_NE(dmGraphics::INVALID_STREAM_OFFSET, mat3_offset);
+    ASSERT_NE(dmGraphics::INVALID_STREAM_OFFSET, mat2_offset);
+
+    const char* vx_data = (const char*) dmGraphics::MapVertexBuffer(m_GraphicsContext, vx_buffer, dmGraphics::BUFFER_ACCESS_READ_ONLY);
 
     // This should be the last value that the script "dynamic_vertex_attributes.script" sets
-    dmVMath::Vector4 exp = dmVMath::Vector4(0.0f, 1.0f, 0.0f, 1.0f);
-    dmVMath::Matrix4 exp_transform(
-        dmVMath::Vector4(1.0f, 2.0f, 3.0f, 4.0f),
-        dmVMath::Vector4(5.0f, 6.0f, 7.0f, 8.0f),
-        dmVMath::Vector4(9.0f, 10.0f, 11.0f, 12.0f),
-        dmVMath::Vector4(13.0f, 14.0f, 15.0f, 16.0f));
+    const float exp_color[4] = { 0.0f, 1.0f, 0.0f, 1.0f };
+    const float exp_transform[16] = {
+        1.0f, 2.0f, 3.0f, 4.0f,
+        5.0f, 6.0f, 7.0f, 8.0f,
+        9.0f, 10.0f, 11.0f, 12.0f,
+        13.0f, 14.0f, 15.0f, 16.0f
+    };
     const float exp_mat3[9] = { 1.0f, 2.0f, 3.0f, 5.0f, 6.0f, 7.0f, 9.0f, 10.0f, 11.0f };
     const float exp_mat2[4] = { 1.0f, 2.0f, 5.0f, 6.0f };
 
     for (int i = 0; i < exp_num_vertices; ++i)
     {
-        ASSERT_VEC4(exp, vx_data[i].custom_color);
-        ASSERT_VEC4(exp_transform[0], vx_data[i].custom_transform[0]);
-        ASSERT_VEC4(exp_transform[1], vx_data[i].custom_transform[1]);
-        ASSERT_VEC4(exp_transform[2], vx_data[i].custom_transform[2]);
-        ASSERT_VEC4(exp_transform[3], vx_data[i].custom_transform[3]);
+        const char* vertex = vx_data + i * vertex_stride;
+        for (uint32_t element = 0; element < 4; ++element)
+        {
+            ASSERT_NEAR(exp_color[element], ReadUnalignedFloat(vertex + color_offset + element * sizeof(float)), EPSILON);
+        }
+        for (uint32_t element = 0; element < 16; ++element)
+        {
+            ASSERT_NEAR(exp_transform[element], ReadUnalignedFloat(vertex + transform_offset + element * sizeof(float)), EPSILON);
+        }
         for (uint32_t element = 0; element < 9; ++element)
         {
-            ASSERT_NEAR(exp_mat3[element], vx_data[i].custom_mat3[element], EPSILON);
+            ASSERT_NEAR(exp_mat3[element], ReadUnalignedFloat(vertex + mat3_offset + element * sizeof(float)), EPSILON);
         }
         for (uint32_t element = 0; element < 4; ++element)
         {
-            ASSERT_NEAR(exp_mat2[element], vx_data[i].custom_mat2[element], EPSILON);
+            ASSERT_NEAR(exp_mat2[element], ReadUnalignedFloat(vertex + mat2_offset + element * sizeof(float)), EPSILON);
         }
     }
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -10124,6 +10124,89 @@ TEST_F(MaterialTest, DynamicVertexAttributes)
     dmResource::Release(m_Factory, material_res);
 }
 
+TEST_F(MaterialTest, DynamicMatrixVertexAttributes)
+{
+    dmGameSystem::MaterialResource* material_res;
+    ASSERT_EQ(dmResource::RESULT_OK, dmResource::Get(m_Factory, "/material/matrix_attributes.materialc", (void**)&material_res));
+    ASSERT_NE((void*)0, material_res);
+
+    dmRender::HMaterial material = material_res->m_Material;
+    DynamicVertexAttributesContext ctx;
+    ctx.m_Attributes.SetCapacity(1);
+
+    dmGameSystem::DynamicAttributePool dynamic_attribute_pool;
+    InitializeMaterialAttributeInfos(dynamic_attribute_pool, 1);
+    uint16_t index = dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX;
+    dmGameObject::PropertyDesc desc = {};
+
+    const float expected_default_mat3[16] = {
+        1.0f, 2.0f, 3.0f, 0.0f,
+        4.0f, 5.0f, 6.0f, 0.0f,
+        7.0f, 8.0f, 9.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    };
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("custom_mat3"), desc, Test_GetMaterialAttributeCallback, &ctx));
+    ASSERT_EQ(dmGameObject::PROPERTY_TYPE_MATRIX4, desc.m_Variant.m_Type);
+    for (uint32_t i = 0; i < 16; ++i)
+    {
+        ASSERT_NEAR(expected_default_mat3[i], desc.m_Variant.m_M4[i], EPSILON);
+    }
+
+    const float expected_default_mat2[16] = {
+        10.0f, 11.0f, 0.0f, 0.0f,
+        12.0f, 13.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    };
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("custom_mat2"), desc, Test_GetMaterialAttributeCallback, &ctx));
+    ASSERT_EQ(dmGameObject::PROPERTY_TYPE_MATRIX4, desc.m_Variant.m_Type);
+    for (uint32_t i = 0; i < 16; ++i)
+    {
+        ASSERT_NEAR(expected_default_mat2[i], desc.m_Variant.m_M4[i], EPSILON);
+    }
+
+    dmGameObject::PropertyVar vector_value(dmVMath::Vector4(1.0f, 2.0f, 3.0f, 4.0f));
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_UNSUPPORTED_TYPE, SetMaterialAttribute(dynamic_attribute_pool, &index, material, dmHashString64("custom_mat2"), vector_value, Test_GetMaterialAttributeCallback, &ctx, 0));
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_UNSUPPORTED_TYPE, SetMaterialAttribute(dynamic_attribute_pool, &index, material, dmHashString64("custom_mat3"), vector_value, Test_GetMaterialAttributeCallback, &ctx, 0));
+    ASSERT_EQ(dmGameSystem::INVALID_DYNAMIC_ATTRIBUTE_INDEX, index);
+
+    dmVMath::Matrix4 matrix_value(
+        dmVMath::Vector4(1.0f, 2.0f, 3.0f, 4.0f),
+        dmVMath::Vector4(5.0f, 6.0f, 7.0f, 8.0f),
+        dmVMath::Vector4(9.0f, 10.0f, 11.0f, 12.0f),
+        dmVMath::Vector4(13.0f, 14.0f, 15.0f, 16.0f));
+    dmGameObject::PropertyVar matrix_property(matrix_value);
+
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, SetMaterialAttribute(dynamic_attribute_pool, &index, material, dmHashString64("custom_mat3"), matrix_property, Test_GetMaterialAttributeCallback, &ctx, 0));
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("custom_mat3"), desc, Test_GetMaterialAttributeCallback, &ctx));
+    const float expected_mat3[16] = {
+        1.0f, 2.0f, 3.0f, 0.0f,
+        5.0f, 6.0f, 7.0f, 0.0f,
+        9.0f, 10.0f, 11.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    };
+    for (uint32_t i = 0; i < 16; ++i)
+    {
+        ASSERT_NEAR(expected_mat3[i], desc.m_Variant.m_M4[i], EPSILON);
+    }
+
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, SetMaterialAttribute(dynamic_attribute_pool, &index, material, dmHashString64("custom_mat2"), matrix_property, Test_GetMaterialAttributeCallback, &ctx, 0));
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, GetMaterialAttribute(dynamic_attribute_pool, index, material, dmHashString64("custom_mat2"), desc, Test_GetMaterialAttributeCallback, &ctx));
+    const float expected_mat2[16] = {
+        1.0f, 2.0f, 0.0f, 0.0f,
+        5.0f, 6.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    };
+    for (uint32_t i = 0; i < 16; ++i)
+    {
+        ASSERT_NEAR(expected_mat2[i], desc.m_Variant.m_M4[i], EPSILON);
+    }
+
+    DestroyMaterialAttributeInfos(dynamic_attribute_pool);
+    dmResource::Release(m_Factory, material_res);
+}
+
 TEST_F(MaterialTest, DynamicVertexAttributesWithGoAnimate)
 {
     ASSERT_TRUE(dmGameObject::Init(m_Collection));
@@ -11355,15 +11438,19 @@ TEST_F(ModelTest, DynamicVertexAttributes)
     dmGraphics::HVertexDeclaration inst_decl;
     dmGameSystem::GetModelComponentAttributeRenderData(component, 0, &vx_buffer, &vx_decl, &inst_decl);
 
-    ASSERT_EQ(2, vx_decl->m_StreamCount);
+    ASSERT_EQ(4, vx_decl->m_StreamCount);
     ASSERT_EQ(dmHashString64("custom_color"), vx_decl->m_Streams[0].m_NameHash);
     ASSERT_EQ(dmHashString64("custom_transform"), vx_decl->m_Streams[1].m_NameHash);
+    ASSERT_EQ(dmHashString64("custom_mat3"), vx_decl->m_Streams[2].m_NameHash);
+    ASSERT_EQ(dmHashString64("custom_mat2"), vx_decl->m_Streams[3].m_NameHash);
 
     // Note: The vertex buffer contains only the custom data, not the position stream!
     struct vx_format
     {
         dmVMath::Vector4 custom_color;
         dmVMath::Matrix4 custom_transform;
+        float custom_mat3[9];
+        float custom_mat2[4];
     };
 
     // Should be a cube with 24 vertices
@@ -11380,6 +11467,8 @@ TEST_F(ModelTest, DynamicVertexAttributes)
         dmVMath::Vector4(5.0f, 6.0f, 7.0f, 8.0f),
         dmVMath::Vector4(9.0f, 10.0f, 11.0f, 12.0f),
         dmVMath::Vector4(13.0f, 14.0f, 15.0f, 16.0f));
+    const float exp_mat3[9] = { 1.0f, 2.0f, 3.0f, 5.0f, 6.0f, 7.0f, 9.0f, 10.0f, 11.0f };
+    const float exp_mat2[4] = { 1.0f, 2.0f, 5.0f, 6.0f };
 
     for (int i = 0; i < exp_num_vertices; ++i)
     {
@@ -11388,6 +11477,14 @@ TEST_F(ModelTest, DynamicVertexAttributes)
         ASSERT_VEC4(exp_transform[1], vx_data[i].custom_transform[1]);
         ASSERT_VEC4(exp_transform[2], vx_data[i].custom_transform[2]);
         ASSERT_VEC4(exp_transform[3], vx_data[i].custom_transform[3]);
+        for (uint32_t element = 0; element < 9; ++element)
+        {
+            ASSERT_NEAR(exp_mat3[element], vx_data[i].custom_mat3[element], EPSILON);
+        }
+        for (uint32_t element = 0; element < 4; ++element)
+        {
+            ASSERT_NEAR(exp_mat2[element], vx_data[i].custom_mat2[element], EPSILON);
+        }
     }
 
     dmGraphics::UnmapVertexBuffer(m_GraphicsContext, vx_buffer);


### PR DESCRIPTION
Fixed an issue where using custom vertex attributes with matrix types did not work correctly with the `go.get()` and `go.set()` functions.  The dynamic attribute implementation only had storage for four floats and converted properties based on element count, which caused several issues. Now, matrix attributes consistently use `vmath.matrix4` types instead:

- `go.set()` accepts a vmath.matrix4 for mat2, mat3, and mat4 attributes.
- Mat2 and mat3 attributes extract the upper-left 2×2 or 3×3 portion.
- `go.get()` returns a vmath.matrix4 for every matrix attribute.
- Mat2 and mat3 values are expanded onto an identity matrix.
- Flattened vector values such as vmath.vector4 are rejected for matrix attributes.

```lua
-- Setting matrix values requires a matrix type as the data container
go.set("#model", "custom_mat4", vmath.matrix4())
go.set("#model", "custom_mat3", vmath.matrix4())
go.set("#model", "custom_mat2", vmath.matrix4())

-- Getting matrix values will return a vmath.matrix4, regardless of the source data size
go.get("#model", "custom_mat4")
go.get("#model", "custom_mat3")
go.get("#model", "custom_mat2")
```

Furthermore, 2x2 matrices could previously be set/get via vmath.vector4 types, but this is no longer supported - you need to use a matrix container for this. Note that this is NOT a breaking change, but merely a bug fix. A matrix type is a matrix type and should be treated as such!

Fixes #13094

#### Technical changes

- Expanded dynamic vertex attribute storage from 4 to 16 floats.
- Added PROPERTY_TYPE_MATRIX4 support to dynamic material attributes.
- Changed property conversion to use the declared vertex attribute type instead of element count.
- Added mat2, mat3, and mat4 conversion helpers.
- Added upper-left matrix extraction for go.set().
- Added identity expansion for go.get().
- Restricted matrix attributes to complete vmath.matrix4 assignments.
- Rejected vector and matrix sub-property assignments for matrix attributes.
- Preserved matrix shape when converting component-level attribute overrides.
- Corrected dynamic render metadata to use the declared attribute vector type.
- Added focused mat2/mat3 property tests and expanded model rendering coverage.