### PR TITLE
Support using 0 samplers for sprites

### DIFF
--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -712,7 +712,10 @@ namespace dmGameSystem
             uint8_t generation = GetTextureResourceGeneration(component, idx);
             dmHashUpdateBuffer32(&state, &generation, sizeof(generation));
         }
-        dmHashUpdateBuffer32(&state, resource->m_Textures->m_TextureSet, sizeof(resource->m_Textures->m_TextureSet));
+        if (resource->m_NumTextures > 0)
+        {
+            dmHashUpdateBuffer32(&state, resource->m_Textures->m_TextureSet, sizeof(resource->m_Textures->m_TextureSet));
+        }
         dmHashUpdateBuffer32(&state, resource->m_Material, sizeof(MaterialResource*));
 
         HashResourceOverrides(&state, component->m_Overrides);

--- a/engine/gamesys/src/gamesys/components/comp_sprite.cpp
+++ b/engine/gamesys/src/gamesys/components/comp_sprite.cpp
@@ -508,7 +508,7 @@ namespace dmGameSystem
         const SpriteTexture* texture = 0;
         if (overrides && index < overrides->m_Textures.Size())
             texture = &overrides->m_Textures[index];
-        if (!texture || !texture->m_TextureSet)
+        if ((!texture || !texture->m_TextureSet) && index < component->m_Resource->m_NumTextures)
             texture = &component->m_Resource->m_Textures[index];
         return texture ? texture->m_TextureSet : 0;
     }
@@ -578,6 +578,9 @@ namespace dmGameSystem
     static void UpdateCurrentAnimationFrame(SpriteComponent* component)
     {
         TextureSetResource* texture_set = GetFirstTextureSet(component);
+        if (!texture_set)
+            return;
+
         dmGameSystemDDF::TextureSet* texture_set_ddf = texture_set->m_TextureSet;
         const dmGameSystemDDF::Playback playback = (dmGameSystemDDF::Playback)component->m_AnimationPlayback;
 
@@ -646,7 +649,14 @@ namespace dmGameSystem
     static bool PlayAnimation(SpriteComponent* component, dmhash_t animation, float offset, float playback_rate)
     {
         TextureSetResource* texture_set = GetFirstTextureSet(component);
-        uint32_t* anim_id = texture_set ? texture_set->m_AnimationIds.Get(animation) : 0;
+        if (!texture_set)
+        {
+            ClearCurrentAnimation(component);
+            dmLogError("Unable to play animation '%s' since the sprite has no texture.", dmHashReverseSafe64(animation));
+            return false;
+        }
+
+        uint32_t* anim_id = texture_set->m_AnimationIds.Get(animation);
         if (anim_id)
         {
             component->m_AnimationID = (uint16_t)(*anim_id);

--- a/engine/gamesys/src/gamesys/test/sprite/build.inputs
+++ b/engine/gamesys/src/gamesys/test/sprite/build.inputs
@@ -16,5 +16,6 @@
 /sprite/test_comp.go
 /sprite/texture_transform_multi.go
 /sprite/texture_transform_sprite.go
+/sprite/textureless.go
 /sprite/valid_sprite.go
 /tile/valid.tileset

--- a/engine/gamesys/src/gamesys/test/sprite/textureless.fp
+++ b/engine/gamesys/src/gamesys/test/sprite/textureless.fp
@@ -1,0 +1,4 @@
+void main()
+{
+    gl_FragColor = vec4(1.0);
+}

--- a/engine/gamesys/src/gamesys/test/sprite/textureless.go
+++ b/engine/gamesys/src/gamesys/test/sprite/textureless.go
@@ -1,0 +1,4 @@
+components {
+  id: "sprite"
+  component: "/sprite/textureless.sprite"
+}

--- a/engine/gamesys/src/gamesys/test/sprite/textureless.material
+++ b/engine/gamesys/src/gamesys/test/sprite/textureless.material
@@ -1,0 +1,7 @@
+name: "textureless"
+vertex_program: "/sprite/sprite.vp"
+fragment_program: "/sprite/textureless.fp"
+vertex_constants {
+  name: "view_proj"
+  type: CONSTANT_TYPE_VIEWPROJ
+}

--- a/engine/gamesys/src/gamesys/test/sprite/textureless.sprite
+++ b/engine/gamesys/src/gamesys/test/sprite/textureless.sprite
@@ -1,0 +1,7 @@
+default_animation: "anim"
+material: "/sprite/textureless.material"
+size {
+  x: 64.0
+  y: 64.0
+}
+size_mode: SIZE_MODE_MANUAL

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2525,11 +2525,24 @@ TEST_F(ResourceComponentTest, ModelTexturePropertyAllTextureSlots)
 // A sprite with a sampler-free material should update and render without a texture set.
 TEST_F(SpriteTest, TexturelessMaterial)
 {
-    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/textureless.goc", dmHashString64("/go"));
+    const dmhash_t go_id = dmHashString64("/go");
+    const dmhash_t sprite_id = dmHashString64("sprite");
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/textureless.goc", go_id);
     ASSERT_NE((void*)0, go);
 
     ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
     ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    PostSpritePlayAnimation(m_Collection, go_id, sprite_id, dmHashString64("anim"), 0.0f, 1.0f);
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
+    dmGameObject::PropertyOptions options;
+    dmGameObject::PropertyVar cursor(0.5);
+    ASSERT_EQ(dmGameObject::PROPERTY_RESULT_OK, dmGameObject::SetProperty(go, sprite_id, dmHashString64("cursor"), options, cursor));
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+
     RenderCollection(m_RenderContext, m_Collection);
 }
 

--- a/engine/gamesys/src/gamesys/test/test_gamesys.cpp
+++ b/engine/gamesys/src/gamesys/test/test_gamesys.cpp
@@ -2522,6 +2522,17 @@ TEST_F(ResourceComponentTest, ModelTexturePropertyAllTextureSlots)
     dmResource::Release(m_Factory, tex_res);
 }
 
+// A sprite with a sampler-free material should update and render without a texture set.
+TEST_F(SpriteTest, TexturelessMaterial)
+{
+    dmGameObject::HInstance go = Spawn(m_Factory, m_Collection, "/sprite/textureless.goc", dmHashString64("/go"));
+    ASSERT_NE((void*)0, go);
+
+    ASSERT_TRUE(dmGameObject::Update(m_Collection, &m_UpdateContext));
+    ASSERT_TRUE(dmGameObject::PostUpdate(m_Collection));
+    RenderCollection(m_RenderContext, m_Collection);
+}
+
 // Test that go.delete() does not influence other sprite animations in progress
 TEST_F(SpriteTest, GoDeletion)
 {


### PR DESCRIPTION
Fixed an engine crash when using sprite components without textures/samplers.

Fixes #12331