### PR TITLE
Fix normalized depth texture uploads on OpenGL ES

### DIFF
--- a/engine/graphics/src/opengl/graphics_opengl.cpp
+++ b/engine/graphics/src/opengl/graphics_opengl.cpp
@@ -2833,11 +2833,11 @@ static void LogFrameBufferError(GLenum status)
             gl_internal_format = DMGRAPHICS_TEXTURE_FORMAT_RG32F;
             break;
         case TEXTURE_FORMAT_DEPTH:
-            gl_type            = GL_FLOAT;
+            // GLES requires an integer upload type for normalized depth storage.
+            gl_type            = GL_UNSIGNED_INT;
             gl_format          = GL_DEPTH_COMPONENT;
             gl_internal_format = GetDepthBufferFormat(context);
         #ifdef __EMSCRIPTEN__
-            gl_type            = GL_UNSIGNED_INT;
             gl_internal_format = context->m_IsGles3Version ? GL_DEPTH_COMPONENT24 : DMGRAPHICS_RENDER_BUFFER_FORMAT_DEPTH16;
         #endif
             break;

--- a/engine/graphics/src/test/test_app_graphics.cpp
+++ b/engine/graphics/src/test/test_app_graphics.cpp
@@ -239,6 +239,59 @@ struct ClearBackbufferTest : ITest
     }
 };
 
+// Run with "opengles depth-texture" to exercise a real depth attachment, not
+// the null adapter used by test_graphics. Graphics-call verification is enabled.
+struct DepthTextureTest : ClearBackbufferTest
+{
+    void Initialize(EngineCtx* engine) override
+    {
+        dmGraphics::HContext context = engine->m_GraphicsContext;
+        for (uint32_t color = 0; color < 2; ++color)
+        {
+            dmGraphics::RenderTargetCreationParams params = {};
+            params.m_DepthTexture                         = 1;
+            params.m_DepthBufferParams.m_Format           = dmGraphics::TEXTURE_FORMAT_DEPTH;
+            params.m_DepthBufferParams.m_Width            = 64;
+            params.m_DepthBufferParams.m_Height           = 64;
+            params.m_DepthBufferCreationParams.m_Width    = 64;
+            params.m_DepthBufferCreationParams.m_Height   = 64;
+            params.m_ColorBufferParams[0].m_Format        = dmGraphics::TEXTURE_FORMAT_RGBA;
+            params.m_ColorBufferParams[0].m_Width         = 64;
+            params.m_ColorBufferParams[0].m_Height        = 64;
+            params.m_ColorBufferCreationParams[0].m_Width  = 64;
+            params.m_ColorBufferCreationParams[0].m_Height = 64;
+
+            uint32_t flags = dmGraphics::BUFFER_TYPE_DEPTH_BIT;
+            if (color)
+            {
+                flags |= dmGraphics::BUFFER_TYPE_COLOR0_BIT;
+            }
+
+            dmGraphics::HRenderTarget target = dmGraphics::NewRenderTarget(context, flags, params);
+            for (uint32_t size = 64; size <= 128; size *= 2)
+            {
+                if (size != 64)
+                {
+                    dmGraphics::SetRenderTargetSize(context, target, size, size);
+                }
+
+                dmGraphics::SetRenderTarget(context, target, 0);
+                dmGraphics::Clear(context, flags, 0, 0, 0, 255, 0.5f, 0);
+                dmGraphics::HTexture depth = dmGraphics::GetRenderTargetTexture(context, target, dmGraphics::BUFFER_TYPE_DEPTH_BIT);
+                if (!dmGraphics::IsAssetHandleValid(context, depth) ||
+                    dmGraphics::GetTextureWidth(context, depth) != size ||
+                    dmGraphics::GetTextureHeight(context, depth) != size)
+                {
+                    dmLogError("Depth texture allocation/resize failed (color=%u, size=%u)", color, size);
+                    engine->m_Failed = true;
+                }
+                dmGraphics::SetRenderTarget(context, 0, 0);
+            }
+            dmGraphics::DeleteRenderTarget(context, target);
+        }
+    }
+};
+
 struct MslArgumentBuffersTest : ITest
 {
     dmGraphics::HProgram           m_Program;
@@ -1333,7 +1386,12 @@ static void* EngineCreate(int argc, char** argv)
         engine->m_Failed = true;
     }
 
-    if (HasArgument("issue-12878"))
+    if (HasArgument("depth-texture"))
+    {
+        dmLogInfo("test_app_graphics: running DepthTextureTest");
+        engine->m_Test = new DepthTextureTest();
+    }
+    else if (HasArgument("issue-12878"))
     {
         dmGraphics::AdapterFamily family = dmGraphics::GetInstalledAdapterFamily();
         if (family != dmGraphics::ADAPTER_FAMILY_VULKAN && family != dmGraphics::ADAPTER_FAMILY_METAL)


### PR DESCRIPTION
Fixes a native OpenGL ES depth-texture allocation failure that can abort the engine with `GL_INVALID_OPERATION`, including on Raspberry Pi 5. Normalized depth textures now use an unsigned integer upload type. No API or render-script changes are required.

### Technical changes

`GetOpenGLSetTextureParams()` paired `TEXTURE_FORMAT_DEPTH` with `GL_FLOAT` on native platforms, although `GetDepthBufferFormat()` selects normalized 16-bit or 24-bit depth storage. GLES requires a compatible integer transfer type for these formats. Use `GL_UNSIGNED_INT`, as the WebGL path already did, and remove the redundant WebGL-only assignment. Floating-point color formats and the WebGL internal-format selection are unchanged.

Reference: [OpenGL ES 3.2 specification, texture format/type combinations](https://registry.khronos.org/OpenGL/specs/es/3.2/es_spec_3.2.pdf).

Adds `DepthTextureTest` to the real-backend graphics test app. It creates, clears, resizes from 64×64 to 128×128, and deletes both depth-only and color-plus-depth render targets, checking the depth texture handles and dimensions. Graphics-call verification is enabled by the existing harness. This deliberately uses the real adapter; the null-adapter render-target unit tests cannot catch an invalid GL format/type pairing.

Run with:

```sh
DEFOLD_TEST_AUTO_EXIT=1 test_app_graphics opengles depth-texture
DEFOLD_TEST_AUTO_EXIT=1 test_app_graphics opengl depth-texture
```

### Validation

- Based on `dev` at `5e9fffa7069af2e97a92379c4602fe25b9c53ffc`.
- Before the fix: real GLES adapter under Mesa/llvmpipe aborts with `OpenGLSetTexture(5532): gl error 1282: GL_INVALID_OPERATION` (exit 134).
- After the fix: the real GLES and desktop OpenGL graphics-app runs pass under Mesa in Linux Docker/Xvfb. The GLES build uses CMake's graphics-library/symbol overrides on x86_64 Linux.
- Existing `test_graphics`: 45 tests, 906 assertions pass.
- Raspberry Pi 5, V3D 7.1.10.2, OpenGL ES 3.1 / Mesa 26.2.1: a separate 8×8 surfaceless EGL probe confirms `DEPTH_COMPONENT24 + FLOAT` returns `0x502`, while `DEPTH_COMPONENT24 + UNSIGNED_INT` and `DEPTH_COMPONENT16 + UNSIGNED_INT` allocate, clear, and produce complete framebuffers. `DEPTH_COMPONENT32F + FLOAT` also succeeds, confirming that genuine floating-point depth storage still requires its own pairing.
- The Pi check is an API-level probe without an engine compatibility shim; the rebuilt-engine tests were run in Docker, not on the Pi. WebGL's existing format/type result is unchanged by inspection; WebGL, Android, and iOS were not rebuilt here.

## PR checklist

- [x] Add a real-backend engine regression test.
- [x] Follow existing code style and comment the format restriction.
- [x] Explain the user-facing fix and validation.
- [x] No API or manual documentation changes needed.
- [ ] Maintainer CI approval/run (fork PR).
- [ ] Contributor License Agreement, if required by the PR check.
