### PR TITLE
Add Android ASAN nightly tests

### DIFF
--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -171,7 +171,9 @@ jobs:
       - name: 'Set up Android SDK'
         uses: defold/github-actions-common/.github/actions/android@73819e712828b4b2261594c33e9d2ba9929249c7
         with:
-          android-ndk: '25.2.9519653'
+          # NDK 27 fixes ASAN allocator collisions with x86_64 ASLR.
+          # https://reviews.llvm.org/D148280
+          android-ndk: '27.0.12077973'
           android-api-level: '${{ env.ANDROID_API_LEVEL }}'
           android-build-tools: '36.1.0'
       - name: 'Install dependencies'

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -15,6 +15,7 @@ on:
           - macos
           - linux-x64
           - linux-arm64
+          - android
           - web
           - windows
           - all
@@ -26,6 +27,7 @@ env:
   DM_ARCHIVE_DOMAIN: ${{ secrets.DM_ARCHIVE_DOMAIN }}
   DM_RELEASE_REPOSITORY: ${{ secrets.DM_RELEASE_REPOSITORY }}
   DOTNET_CHANNEL: 9.0.1xx
+  ANDROID_API_LEVEL: "36"
 
 jobs:
   bld-eng-macos-64:
@@ -141,6 +143,75 @@ jobs:
          with: { webhook: '${{ secrets.SLACK_WEBHOOK }}', webhook-type: incoming-webhook, errors: true,
                  payload: '{"channel":"#defold-alarms-build","text":"<!here> *${{ job.status }}*: ${{ github.workflow }} / ${{ github.job }}\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Open run> · <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"}' }
       }]
+
+  bld-eng-android-x64:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'android' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2
+      - name: 'Install Python'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: 'Install Java'
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+          cache-dependency-path: |-
+            com.dynamo.cr/com.dynamo.cr.bob/*.gradle
+            com.dynamo.cr/com.dynamo.cr.bob/gradle/wrapper/gradle-wrapper.properties
+            com.dynamo.cr/com.dynamo.cr.bob.test/*.gradle
+            com.dynamo.cr/com.dynamo.cr.bob.test/gradle/wrapper/gradle-wrapper.properties
+      - name: 'Install CMake'
+        uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.3.2
+      - name: 'Set up Android SDK'
+        uses: defold/github-actions-common/.github/actions/android@73819e712828b4b2261594c33e9d2ba9929249c7
+        with:
+          android-ndk: '25.2.9519653'
+          android-api-level: '${{ env.ANDROID_API_LEVEL }}'
+          android-build-tools: '36.1.0'
+      - name: 'Install dependencies'
+        run: 'ci/ci.sh install --platform=x86_64-android'
+      - name: 'Enable KVM'
+        run: |-
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: 'Cache Android AVD'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |-
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: '${{ runner.os }}-avd-${{ env.ANDROID_API_LEVEL }}-google_apis-x86_64'
+      - name: 'ASAN on Android emulator'
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: '${{ env.ANDROID_API_LEVEL }}'
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          disable-animations: true
+          emulator-options: '-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save -camera-back none -camera-front none'
+          # Keep the emulator running for both the engine build and its tests.
+          script: |-
+            ANDROID_SERIAL=$(adb devices | awk '$2=="device"{print $1; exit}')
+            if [ -z "$ANDROID_SERIAL" ]; then echo 'No Android device attached, refusing to skip the tests silently'; exit 1; fi
+            export ANDROID_SERIAL
+            python build_tools/build_android.py can-run-tests --platform x86_64-android --device "$ANDROID_SERIAL"
+            ci/ci.sh --platform=x86_64-android --with-asan --skip-builtins --skip-docs engine
+      - name: 'Notify if build status changed'
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v3.0.5
+        if: failure()
+        with:
+          webhook: '${{ secrets.SLACK_WEBHOOK }}'
+          webhook-type: incoming-webhook
+          errors: true
+          payload: '{"channel":"#defold-alarms-build","text":"<!here> *${{ job.status }}*: ${{ github.workflow }} / ${{ github.job }}\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Open run> · <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"}'
 
   bld-eng-web:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'web' }}

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -177,7 +177,10 @@ jobs:
           android-api-level: '${{ env.ANDROID_API_LEVEL }}'
           android-build-tools: '36.1.0'
       - name: 'Install dependencies'
-        run: 'ci/ci.sh install --platform=x86_64-android'
+        run: |-
+          # Chrome is unused here; exclude its repository from dependency updates.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+          ci/ci.sh install --platform=x86_64-android
       - name: 'Enable KVM'
         run: |-
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/build_tools/build_android.py
+++ b/build_tools/build_android.py
@@ -1,6 +1,7 @@
 import argparse
 import configparser
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -247,6 +248,9 @@ class AndroidTestRunner(object):
         self._adb = get_adb_command(self._env, adb)
         self._device = get_device_name(self._env, device)
         self._log_fn = log_fn
+        self._asan_runtime = self._env.get('ANDROID_ASAN_RUNTIME')
+        if self._asan_runtime and not os.path.isfile(self._asan_runtime):
+            raise RuntimeError('android-test: ASAN runtime not found: %s' % self._asan_runtime)
         self.device_root = device_root
         self._prepared = False
         self._library_name = None
@@ -363,6 +367,12 @@ class AndroidTestRunner(object):
             self._log('android-test: failed to create device folder')
             return ret
 
+        if self._asan_runtime:
+            runtime_path = '%s/%s' % (self._library_root, os.path.basename(self._asan_runtime))
+            ret = self._push_file(self._asan_runtime, runtime_path)
+            if ret != 0:
+                return ret
+
         if folders != None:
             for source, target in folders.items():
                 ret = self._push_source_path(cwd, source, target)
@@ -418,7 +428,18 @@ class AndroidTestRunner(object):
             self._log('android-test: failed to chmod test binary')
             return ret
 
-        cmd = ['shell', 'cd', self._library_root, '&&', './%s' % device_program]
+        cmd = ['shell', 'cd', shlex.quote(self._library_root), '&&']
+        if self._asan_runtime:
+            # adb does not forward the host environment. Load the NDK runtime
+            # beside the executable and keep ASAN diagnostics in the test log.
+            asan_options = 'log_to_syslog=false:allow_user_segv_handler=1'
+            if self._env.get('ASAN_OPTIONS'):
+                asan_options += ':' + self._env['ASAN_OPTIONS']
+            cmd.extend([
+                'LD_LIBRARY_PATH=%s' % shlex.quote(self._library_root),
+                'ASAN_OPTIONS=%s' % shlex.quote(asan_options),
+            ])
+        cmd.append(shlex.quote('./%s' % device_program))
         if self._configfile:
             relative_config = './unittest.cfg'
             self._log('android-test: using staged config file %s' % relative_config)

--- a/engine/script/CMakeLists.txt
+++ b/engine/script/CMakeLists.txt
@@ -109,6 +109,11 @@ target_include_directories(script PUBLIC
 target_compile_definitions(script PRIVATE
   "DLIB_LOG_DOMAIN=\"SCRIPT\""
   "LUASOCKET_API=")
+if(WITH_ASAN AND TARGET_PLATFORM_OS STREQUAL "android")
+  # The NDK's static unwinder bypasses ASAN's runtime interceptor.
+  target_compile_definitions(script PRIVATE DM_ASAN_WRAP_UNWIND)
+  target_link_options(script INTERFACE "LINKER:--wrap=_Unwind_RaiseException")
+endif()
 if(TARGET graphics_proto)
   add_dependencies(script graphics_proto_header)
 endif()

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -44,6 +44,20 @@ extern "C"
 #undef luaL_error
 extern "C" void __asan_handle_no_return();
 
+#if defined(DM_ASAN_WRAP_UNWIND)
+#include <unwind.h>
+
+extern "C" _Unwind_Reason_Code __real__Unwind_RaiseException(_Unwind_Exception* exception_object);
+
+extern "C" _Unwind_Reason_Code __wrap__Unwind_RaiseException(_Unwind_Exception* exception_object)
+{
+    // LuaJIT's internal errors bypass the lua_error/luaL_error wrappers below.
+    // Clear ASAN stack metadata before the unwinder discards those C/C++ frames.
+    __asan_handle_no_return();
+    return __real__Unwind_RaiseException(exception_object);
+}
+#endif
+
 extern "C" int dm_lua_error_asan(lua_State* L)
 {
     __asan_handle_no_return();

--- a/engine/script/src/script.cpp
+++ b/engine/script/src/script.cpp
@@ -39,46 +39,6 @@ extern "C"
 #include <lua/lualib.h>
 }
 
-#if defined(DM_SANITIZE_ADDRESS) && !defined(_MSC_VER)
-#undef lua_error
-#undef luaL_error
-extern "C" void __asan_handle_no_return();
-
-#if defined(DM_ASAN_WRAP_UNWIND)
-#include <unwind.h>
-
-extern "C" _Unwind_Reason_Code __real__Unwind_RaiseException(_Unwind_Exception* exception_object);
-
-extern "C" _Unwind_Reason_Code __wrap__Unwind_RaiseException(_Unwind_Exception* exception_object)
-{
-    // LuaJIT's internal errors bypass the lua_error/luaL_error wrappers below.
-    // Clear ASAN stack metadata before the unwinder discards those C/C++ frames.
-    __asan_handle_no_return();
-    return __real__Unwind_RaiseException(exception_object);
-}
-#endif
-
-extern "C" int dm_lua_error_asan(lua_State* L)
-{
-    __asan_handle_no_return();
-    return DM_LUA_RENAME(lua_error)(L);
-}
-
-extern "C" int dm_luaL_error_asan(lua_State* L, const char* fmt, ...)
-{
-    va_list argp;
-    va_start(argp, fmt);
-    luaL_where(L, 1);
-    lua_pushvfstring(L, fmt, argp);
-    va_end(argp);
-    lua_concat(L, 2);
-    return dm_lua_error_asan(L);
-}
-
-#define lua_error dm_lua_error_asan
-#define luaL_error dm_luaL_error_asan
-#endif
-
 DM_PROPERTY_GROUP(rmtp_Script, "", 0);
 
 namespace dmScript

--- a/engine/script/src/script_asan.cpp
+++ b/engine/script/src/script_asan.cpp
@@ -1,0 +1,59 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#if defined(DM_SANITIZE_ADDRESS) && !defined(_MSC_VER)
+extern "C"
+{
+#include <lua/lua.h>
+#include <lua/lauxlib.h>
+}
+
+#undef lua_error
+#undef luaL_error
+
+extern "C" void __asan_handle_no_return();
+
+// Keep the sanitizer wrappers in their own object so linking them doesn't
+// pull in script initialization.
+extern "C" int dm_lua_error_asan(lua_State* L)
+{
+    __asan_handle_no_return();
+    return DM_LUA_RENAME(lua_error)(L);
+}
+
+extern "C" int dm_luaL_error_asan(lua_State* L, const char* fmt, ...)
+{
+    va_list argp;
+    va_start(argp, fmt);
+    luaL_where(L, 1);
+    lua_pushvfstring(L, fmt, argp);
+    va_end(argp);
+    lua_concat(L, 2);
+    return dm_lua_error_asan(L);
+}
+
+#if defined(DM_ASAN_WRAP_UNWIND)
+#include <unwind.h>
+
+extern "C" _Unwind_Reason_Code __real__Unwind_RaiseException(_Unwind_Exception* exception_object);
+
+extern "C" _Unwind_Reason_Code __wrap__Unwind_RaiseException(_Unwind_Exception* exception_object)
+{
+    // LuaJIT's internal errors bypass the lua_error/luaL_error wrappers.
+    // Clear ASAN stack metadata before the unwinder discards those C/C++ frames.
+    __asan_handle_no_return();
+    return __real__Unwind_RaiseException(exception_object);
+}
+#endif
+#endif

--- a/engine/script/src/test/test_script_lua.cpp
+++ b/engine/script/src/test/test_script_lua.cpp
@@ -23,6 +23,11 @@
 #include <string.h>
 #include <setjmp.h>
 
+#if defined(DM_SANITIZE_ADDRESS) && defined(ANDROID)
+#include <alloca.h>
+#include <sanitizer/asan_interface.h>
+#endif
+
 class ScriptTestLua : public dmScriptTest::ScriptTest
 {
 };
@@ -426,6 +431,46 @@ TEST_F(ScriptTestLua, TestErrorHandler) {
     ASSERT_EQ(LUA_ERRRUN, result);
     ASSERT_EQ(top, lua_gettop(L));
 }
+
+#if defined(DM_SANITIZE_ADDRESS) && defined(ANDROID)
+struct LuaErrorStackRange
+{
+    uintptr_t m_Begin;
+    uintptr_t m_End;
+};
+
+static int CheckArgumentWithStackBuffers(lua_State* L)
+{
+    LuaErrorStackRange* range = (LuaErrorStackRange*)lua_touserdata(L, lua_upvalueindex(1));
+    // Dynamic allocations stay on the real stack even with ASAN's fake stack enabled.
+    size_t size = 256 + lua_gettop(L) % 2;
+    char* first = (char*)alloca(size);
+    char* second = (char*)alloca(size);
+    memset(first, 0, size);
+    memset(second, 0, size);
+    range->m_Begin = (uintptr_t)first < (uintptr_t)second ? (uintptr_t)first : (uintptr_t)second;
+    range->m_End = ((uintptr_t)first > (uintptr_t)second ? (uintptr_t)first : (uintptr_t)second) + size;
+    lua_pushlstring(L, first, size);
+    lua_pushlstring(L, second, size);
+    // This error originates inside LuaJIT and bypasses our luaL_error wrapper.
+    luaL_checktype(L, 1, LUA_TNUMBER);
+    return 0;
+}
+
+TEST_F(ScriptTestLua, TestArgumentErrorClearsAsanStack)
+{
+    LuaErrorStackRange range = {};
+    lua_pushlightuserdata(L, &range);
+    lua_pushcclosure(L, CheckArgumentWithStackBuffers, 1);
+    lua_pushboolean(L, 1);
+    int result = lua_pcall(L, 1, 0, 0);
+    // Inspect only sanitizer metadata, never the discarded stack objects themselves.
+    void* poisoned = __asan_region_is_poisoned((void*)range.m_Begin, range.m_End - range.m_Begin);
+    lua_pop(L, 1);
+    ASSERT_EQ(LUA_ERRRUN, result);
+    ASSERT_EQ((void*)0, poisoned);
+}
+#endif
 
 TEST_F(ScriptTestLua, TestStackCheck) {
 

--- a/scripts/cmake/functions_test.cmake
+++ b/scripts/cmake/functions_test.cmake
@@ -390,7 +390,7 @@ function(_defold_register_android_batch_target out_var target_name run_dir_norm 
 
   if(NOT TARGET ${_prepare_target})
     add_custom_target(${_prepare_target}
-      COMMAND "${_python}" "${_runner}" prepare --cwd "${run_dir_norm}" ${_config_args} ${_stage_args}
+      COMMAND ${DEFOLD_ANDROID_TEST_ENV} "${_python}" "${_runner}" prepare --cwd "${run_dir_norm}" ${_config_args} ${_stage_args}
       USES_TERMINAL
       COMMAND_EXPAND_LISTS
       COMMENT "Preparing Android test library in ${run_dir_norm}")
@@ -402,7 +402,7 @@ function(_defold_register_android_batch_target out_var target_name run_dir_norm 
 
   if(NOT TARGET ${_batch_run_target})
     add_custom_target(${_batch_run_target}
-      COMMAND "${_python}" "${_runner}" run-test --cwd "${run_dir_norm}" --program "$<TARGET_FILE:${target_name}>" ${_config_args}
+      COMMAND ${DEFOLD_ANDROID_TEST_ENV} "${_python}" "${_runner}" run-test --cwd "${run_dir_norm}" --program "$<TARGET_FILE:${target_name}>" ${_config_args}
       DEPENDS ${target_name} ${_prepare_target}
       USES_TERMINAL
       COMMAND_EXPAND_LISTS
@@ -643,8 +643,8 @@ function(defold_register_test_target target_name)
         endif()
         _defold_build_stage_file_args(_stage_args ${DEFOLD_TEST_STAGE_FILES})
         add_custom_target(${_run_target}
-          COMMAND "${_python}" "${_runner}" prepare --cwd "${_RUN_DIR_NORM}" ${_config_args} ${_stage_args}
-          COMMAND "${_python}" "${_runner}" run-test --cwd "${_RUN_DIR_NORM}" --program "$<TARGET_FILE:${target_name}>" ${_config_args}
+          COMMAND ${DEFOLD_ANDROID_TEST_ENV} "${_python}" "${_runner}" prepare --cwd "${_RUN_DIR_NORM}" ${_config_args} ${_stage_args}
+          COMMAND ${DEFOLD_ANDROID_TEST_ENV} "${_python}" "${_runner}" run-test --cwd "${_RUN_DIR_NORM}" --program "$<TARGET_FILE:${target_name}>" ${_config_args}
           COMMAND "${_python}" "${_runner}" stop --cwd "${_RUN_DIR_NORM}" ${_config_args}
           DEPENDS ${target_name}
           USES_TERMINAL

--- a/scripts/cmake/functions_testserver.cmake
+++ b/scripts/cmake/functions_testserver.cmake
@@ -143,7 +143,7 @@ function(defold_register_test_with_server target platform)
   set(_run_target "run_${target}_server")
   if(NOT TARGET ${_run_target})
     add_custom_target(${_run_target}
-      COMMAND "${DEFOLD_TESTSERVER_PYTHON3_EXECUTABLE}" "${_WRAP}"
+      COMMAND ${DEFOLD_ANDROID_TEST_ENV} "${DEFOLD_TESTSERVER_PYTHON3_EXECUTABLE}" "${_WRAP}"
         --workdir "${_RUN_DIR_ABS}"
         --ip "${_SERVER_IP}"
         --port "${DTS_PORT}"
@@ -281,7 +281,7 @@ function(defold_register_tests_with_server group platform)
 
   if(NOT TARGET ${_run_target})
     add_custom_target(${_run_target}
-      COMMAND "${DEFOLD_TESTSERVER_PYTHON3_EXECUTABLE}" "${_WRAP}"
+      COMMAND ${DEFOLD_ANDROID_TEST_ENV} "${DEFOLD_TESTSERVER_PYTHON3_EXECUTABLE}" "${_WRAP}"
         --workdir "${_RUN_DIR_ABS}"
         --ip "${_SERVER_IP}"
         --port "${DTS_PORT}"

--- a/scripts/cmake/platform_android.cmake
+++ b/scripts/cmake/platform_android.cmake
@@ -20,7 +20,7 @@ target_compile_options(defold_sdk INTERFACE
   -fno-strict-aliasing
   -funwind-tables)
 
-if(NOT WITH_HWASAN)
+if(NOT WITH_HWASAN AND NOT WITH_ASAN)
     target_compile_options(defold_sdk INTERFACE -fomit-frame-pointer)
 endif()
 
@@ -61,4 +61,26 @@ target_link_options(defold_sdk INTERFACE
 
 if(NOT WITH_HWASAN)
     target_link_options(defold_sdk INTERFACE -static-libstdc++)
+endif()
+
+set(DEFOLD_ANDROID_TEST_ENV)
+if(WITH_ASAN AND BUILD_TESTS)
+    if(TARGET_PLATFORM STREQUAL "arm64-android")
+        set(_asan_arch aarch64)
+    elseif(TARGET_PLATFORM STREQUAL "x86_64-android")
+        set(_asan_arch x86_64)
+    else()
+        set(_asan_arch arm)
+    endif()
+    # Query the compiler so the runtime always matches the NDK used to build.
+    execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" "--target=${CMAKE_CXX_COMPILER_TARGET}"
+            "--print-file-name=libclang_rt.asan-${_asan_arch}-android.so"
+        RESULT_VARIABLE _asan_result
+        OUTPUT_VARIABLE _asan_runtime
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _asan_result EQUAL 0 OR NOT EXISTS "${_asan_runtime}")
+        message(FATAL_ERROR "Android ASAN runtime not found: ${_asan_runtime}")
+    endif()
+    set(DEFOLD_ANDROID_TEST_ENV "${CMAKE_COMMAND}" -E env "ANDROID_ASAN_RUNTIME=${_asan_runtime}")
 endif()


### PR DESCRIPTION
Nightly engine builds now run Android tests with AddressSanitizer on an emulator to detect memory errors. The Android job can also be started manually and fails if no test device is available.

### Technical changes

- Add an x86_64 Android CI job using API 36, NDK 27, KVM, and a cached emulator.
- Locate and stage the matching NDK ASAN runtime, pass sanitizer settings through regular and server-backed test targets, and preserve frame pointers.
- Clear ASAN stack metadata during LuaJIT error unwinding on Android to prevent false sanitizer reports.
- Move Lua ASAN wrappers into a separate source file so linking them does not pull in script initialization.
- Add an Android ASAN regression test verifying that Lua argument errors leave discarded stack regions unpoisoned.
- We added `script_asan.cpp` to isolate Lua/LuaJIT’s ASAN error-unwinding wrappers, so tests can link them without pulling in script initialization and its dependencies.