### PR TITLE
Reduce bundled engines in Bob and the editor

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/HTML5BundlerTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/bundle/test/HTML5BundlerTest.java
@@ -15,11 +15,33 @@
 package com.dynamo.bob.bundle.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import com.dynamo.bob.Bob;
+import com.dynamo.bob.EngineArtifactsProvider;
+import com.dynamo.bob.Platform;
+import com.dynamo.bob.Project;
+import com.dynamo.bob.bundle.BundleHelper;
 import com.dynamo.bob.bundle.HTML5Bundler;
+import com.dynamo.bob.fs.DefaultFileSystem;
 
 /**
  * Tests for HTML5Bundler.getUrlOrigin(), which decides if index.html should contain a
@@ -27,6 +49,54 @@ import com.dynamo.bob.bundle.HTML5Bundler;
  * A null result means "no hint", ie the archive is loaded from the same origin as index.html.
  */
 public class HTML5BundlerTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testMissingPthreadEngineAbortsBundle() throws Exception {
+        // Local Bob builds may still embed this engine. The download failure only
+        // applies when it is absent, as in the default Bob distribution.
+        assumeTrue(Bob.class.getResource("/libexec/wasm_pthread-web/dmengine_release.js") == null);
+        Bob.init();
+        assumeTrue(!new File(Bob.getRootFolder(), "wasm_pthread-web/dmengine_release.js").exists());
+
+        File projectDir = temporaryFolder.newFolder("project");
+        File buildDir = new File(projectDir, "build");
+        assertTrue(buildDir.mkdirs());
+        for (String name : BundleHelper.getArchiveFilenames(buildDir)) {
+            Files.write(new File(buildDir, name).toPath(), new byte[] {1});
+        }
+        File bundleDir = temporaryFolder.newFolder("bundle");
+        ProxySelector previousProxySelector = ProxySelector.getDefault();
+        EngineArtifactsProvider.setCacheBase(temporaryFolder.newFolder("cache"));
+        try (Project project = new Project(new DefaultFileSystem(), projectDir.getAbsolutePath(), "build")) {
+            // Force a connection failure without contacting the engine archive.
+            ProxySelector.setDefault(new ProxySelector() {
+                @Override
+                public List<Proxy> select(URI uri) {
+                    return List.of(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 0)));
+                }
+
+                @Override
+                public void connectFailed(URI uri, SocketAddress address, IOException error) {
+                }
+            });
+            project.setOption("architectures", "wasm_pthread-web");
+            project.setOption("variant", Bob.VARIANT_RELEASE);
+            project.getProjectProperties().putStringValue("project", "title", "OfflineTest");
+            try {
+                new HTML5Bundler().bundleApplication(project, Platform.WasmPthreadWeb, bundleDir, () -> false);
+                fail("Expected bundling to fail when the pthread engine cannot be downloaded");
+            } catch (IOException e) {
+                assertTrue(e.getMessage().contains("release engine for wasm_pthread-web (dmengine_release.js)"));
+                assertTrue(e.getMessage().contains("Check your internet connection and try again."));
+                assertFalse(new File(bundleDir, "OfflineTest/dmloader.js").exists());
+            }
+        } finally {
+            ProxySelector.setDefault(previousProxySelector);
+            EngineArtifactsProvider.setCacheBase(null);
+        }
+    }
 
     // The default value of html5.archive_location_prefix and other relative prefixes must not
     // produce a preconnect hint, since they are served from the same origin as index.html.

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/EngineArtifactsProviderTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/EngineArtifactsProviderTest.java
@@ -1,0 +1,165 @@
+// Copyright 2020-2026 The Defold Foundation
+// Copyright 2014-2020 King
+// Copyright 2009-2014 Ragnar Svensson, Christian Murray
+// Licensed under the Defold License version 1.0 (the "License"); you may not use
+// this file except in compliance with the License.
+//
+// You may obtain a copy of the License, together with FAQs at
+// https://www.defold.com/license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package com.dynamo.bob.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.dynamo.bob.Bob;
+import com.dynamo.bob.EngineArtifactsProvider;
+import com.dynamo.bob.Platform;
+import com.dynamo.bob.Progress;
+import com.dynamo.bob.Project;
+import com.dynamo.bob.archive.EngineVersion;
+import com.dynamo.bob.fs.DefaultFileSystem;
+
+public class EngineArtifactsProviderTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File archive;
+    private File cache;
+
+    @Before
+    public void setUp() throws IOException {
+        archive = temporaryFolder.newFolder("archive");
+        cache = temporaryFolder.newFolder("cache");
+        EngineArtifactsProvider.setCacheBase(cache);
+    }
+
+    @After
+    public void tearDown() {
+        EngineArtifactsProvider.setCacheBase(null);
+    }
+
+    // Use a file-backed archive to exercise downloads and cache reuse without a server.
+    @SuppressWarnings("unchecked")
+    private List<File> downloadExes(Platform platform, String variant) throws Exception {
+        Method method = EngineArtifactsProvider.class.getDeclaredMethod("downloadExes", Platform.class, String.class, String.class);
+        method.setAccessible(true);
+        try {
+            return (List<File>) method.invoke(null, platform, variant, archive.toURI().toString());
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof Exception) {
+                throw (Exception) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    private File writeArtifact(String platformKey, String path, String content) throws IOException {
+        File file = new File(archive, EngineVersion.sha1 + "/engine/" + platformKey + "/" + path);
+        FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);
+        return file;
+    }
+
+    private void checkEngineDownloads(Platform platform, String artifactDirectory) throws Exception {
+        String[] variants = {Bob.VARIANT_DEBUG, Bob.VARIANT_RELEASE, Bob.VARIANT_HEADLESS};
+        String[] names = {"dmengine", "dmengine_release", "dmengine_headless"};
+        for (int i = 0; i < variants.length; ++i) {
+            List<String> filenames = platform.formatBinaryName(names[i]);
+            for (String filename : filenames) {
+                if (!artifactDirectory.isEmpty()) {
+                    writeArtifact(platform.getPair(), filename, "unstripped symbols");
+                }
+                writeArtifact(platform.getPair(), artifactDirectory + filename, "engine " + filename);
+            }
+
+            List<File> downloaded = downloadExes(platform, variants[i]);
+            assertEquals(filenames.size(), downloaded.size());
+            for (int j = 0; j < filenames.size(); ++j) {
+                assertEquals(filenames.get(j), downloaded.get(j).getName());
+                assertEquals("engine " + filenames.get(j), Files.readString(downloaded.get(j).toPath()));
+                Files.delete(new File(archive, EngineVersion.sha1 + "/engine/" + platform.getPair() + "/" + artifactDirectory + filenames.get(j)).toPath());
+            }
+            assertEquals(downloaded, downloadExes(platform, variants[i]));
+        }
+    }
+
+    @Test
+    public void testNativeEnginesUseStrippedArtifactsAndReuseCache() throws Exception {
+        Platform[] platforms = {Platform.Arm64Linux, Platform.Arm64IosSim, Platform.X86_64Android,
+                Platform.Armv7Android, Platform.Arm64Android, Platform.Arm64Ios,
+                Platform.X86_64Linux, Platform.X86_64MacOS, Platform.Arm64MacOS};
+        for (Platform platform : platforms) {
+            checkEngineDownloads(platform, "stripped/");
+        }
+    }
+
+    @Test
+    public void testWebAndWindowsEnginesUseOriginalArtifactsAndReuseCache() throws Exception {
+        Platform[] platforms = {Platform.WasmWeb, Platform.WasmPthreadWeb, Platform.X86Win32, Platform.X86_64Win32};
+        for (Platform platform : platforms) {
+            checkEngineDownloads(platform, "");
+        }
+    }
+
+    @Test
+    public void testAndroidSymbolsAndStrippedEngineHaveSeparateCaches() throws Exception {
+        Platform platform = Platform.X86_64Android;
+        String filename = "libdmengine_release.so";
+        File cachedSymbols = new File(cache, platform.getPair() + "/" + EngineVersion.sha1 + "/" + filename);
+        FileUtils.writeStringToFile(cachedSymbols, "unstripped symbols", StandardCharsets.UTF_8);
+        writeArtifact(platform.getPair(), "stripped/" + filename, "stripped engine");
+
+        File engine = downloadExes(platform, Bob.VARIANT_RELEASE).get(0);
+        assertEquals("stripped engine", Files.readString(engine.toPath()));
+        assertEquals("unstripped symbols", Files.readString(cachedSymbols.toPath()));
+
+        try (Project project = new Project(new DefaultFileSystem(), temporaryFolder.newFolder("project").getAbsolutePath(), "build")) {
+            project.setOption("architectures", platform.getPair());
+            project.setOption("variant", Bob.VARIANT_RELEASE);
+            EngineArtifactsProvider.downloadSymbols(project, Progress.discarding());
+            File symbols = new File(project.getBinaryOutputDirectory(), platform.getExtenderPair() + "/" + filename);
+            assertEquals("unstripped symbols", Files.readString(symbols.toPath()));
+            assertEquals("stripped engine", Files.readString(engine.toPath()));
+        }
+    }
+
+    @Test
+    public void testLegacyPlatformFallbackUsesStrippedArtifacts() throws Exception {
+        writeArtifact("android", "stripped/libdmengine.so", "legacy stripped engine");
+        File engine = downloadExes(Platform.Armv7Android, Bob.VARIANT_DEBUG).get(0);
+        assertEquals("legacy stripped engine", Files.readString(engine.toPath()));
+    }
+
+    @Test
+    public void testMissingPthreadWasmReportsDownloadFailure() throws Exception {
+        writeArtifact("wasm_pthread-web", "dmengine_release.js", "engine loader");
+        try {
+            downloadExes(Platform.WasmPthreadWeb, Bob.VARIANT_RELEASE);
+            fail("Expected the missing WASM artifact to fail the download");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("release engine for wasm_pthread-web (dmengine_release.wasm)"));
+            assertTrue(e.getMessage().contains("Check your internet connection and try again."));
+        }
+    }
+}

--- a/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
+++ b/com.dynamo.cr/com.dynamo.cr.bob/scripts/copy.sh
@@ -34,12 +34,12 @@ mkdir -p libexec/arm64-macos
 # mkdir -p libexec/x86-win32
 mkdir -p libexec/x86_64-win32
 mkdir -p libexec/arm64-ios
-mkdir -p libexec/arm64_sim-ios
+# mkdir -p libexec/arm64_sim-ios
 # mkdir -p libexec/armv7-android
 mkdir -p libexec/arm64-android
-mkdir -p libexec/x86_64-android
+# mkdir -p libexec/x86_64-android
 mkdir -p libexec/wasm-web
-mkdir -p libexec/wasm_pthread-web
+# mkdir -p libexec/wasm_pthread-web
 
 cp -v "$DYNAMO_HOME/ext/share/java/bundletool-all.jar" libexec/bundletool-all.jar
 
@@ -182,8 +182,8 @@ if [ -d "$DYNAMO_HOME/archive/$SHA1" ]; then
 copy x86_64-linux/stripped/dmengine x86_64-linux/dmengine
 copy x86_64-linux/stripped/dmengine_release x86_64-linux/dmengine_release
 # copy x86_64-linux/stripped/dmengine_headless x86_64-linux/dmengine_headless
-copy arm64-linux/stripped/dmengine arm64-linux/dmengine
-copy arm64-linux/stripped/dmengine_release arm64-linux/dmengine_release
+# copy arm64-linux/stripped/dmengine arm64-linux/dmengine
+# copy arm64-linux/stripped/dmengine_release arm64-linux/dmengine_release
 # copy arm64-linux/stripped/dmengine_headless arm64-linux/dmengine_headless
 copy x86_64-macos/stripped/dmengine x86_64-macos/dmengine
 copy x86_64-macos/stripped/dmengine_release x86_64-macos/dmengine_release
@@ -199,23 +199,23 @@ copy x86_64-win32/dmengine_release.exe x86_64-win32/dmengine_release.exe
 # copy x86_64-win32/dmengine_headless.exe x86_64-win32/dmengine_headless.exe
 copy arm64-ios/stripped/dmengine arm64-ios/dmengine
 copy arm64-ios/stripped/dmengine_release arm64-ios/dmengine_release
-copy arm64_sim-ios/stripped/dmengine arm64_sim-ios/dmengine
-copy arm64_sim-ios/stripped/dmengine_release arm64_sim-ios/dmengine_release
+# copy arm64_sim-ios/stripped/dmengine arm64_sim-ios/dmengine
+# copy arm64_sim-ios/stripped/dmengine_release arm64_sim-ios/dmengine_release
 # copy armv7-android/stripped/libdmengine.so armv7-android/libdmengine.so
 # copy armv7-android/stripped/libdmengine_release.so armv7-android/libdmengine_release.so
 copy arm64-android/stripped/libdmengine.so arm64-android/libdmengine.so # TODO only valid once arm64-android CI target is present --jbnn
 copy arm64-android/stripped/libdmengine_release.so arm64-android/libdmengine_release.so # TODO only valid once arm64-android CI target is present --jbnn
-copy x86_64-android/stripped/libdmengine.so x86_64-android/libdmengine.so
-copy x86_64-android/stripped/libdmengine_release.so x86_64-android/libdmengine_release.so
+# copy x86_64-android/stripped/libdmengine.so x86_64-android/libdmengine.so
+# copy x86_64-android/stripped/libdmengine_release.so x86_64-android/libdmengine_release.so
 copy wasm-web/dmengine.js wasm-web/dmengine.js
 copy wasm-web/dmengine.wasm wasm-web/dmengine.wasm
 copy wasm-web/dmengine_release.js wasm-web/dmengine_release.js
 copy wasm-web/dmengine_release.wasm wasm-web/dmengine_release.wasm
 
-copy wasm_pthread-web/dmengine.js wasm_pthread-web/dmengine.js
-copy wasm_pthread-web/dmengine.wasm wasm_pthread-web/dmengine.wasm
-copy wasm_pthread-web/dmengine_release.js wasm_pthread-web/dmengine_release.js
-copy wasm_pthread-web/dmengine_release.wasm wasm_pthread-web/dmengine_release.wasm
+# copy wasm_pthread-web/dmengine.js wasm_pthread-web/dmengine.js
+# copy wasm_pthread-web/dmengine.wasm wasm_pthread-web/dmengine.wasm
+# copy wasm_pthread-web/dmengine_release.js wasm_pthread-web/dmengine_release.js
+# copy wasm_pthread-web/dmengine_release.wasm wasm_pthread-web/dmengine_release.wasm
 
 fi
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Bob.java
@@ -74,7 +74,7 @@ public class Bob {
     public static final String VARIANT_RELEASE = "release";
     public static final String VARIANT_HEADLESS = "headless";
 
-    public static final String ARTIFACTS_URL = "http://d.defold.com/archive/";
+    public static final String ARTIFACTS_URL = "https://d.defold.com/archive/";
 
     private static File rootFolder = null;
 

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/EngineArtifactsProvider.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/EngineArtifactsProvider.java
@@ -84,7 +84,7 @@ public final class EngineArtifactsProvider {
                 if (symbolsFilename != null) {
                     try {
                         String fallbackKey = (p != null) ? p.getOs() : null;
-                        File cached = getOrDownloadArtifact(platformKey, symbolsFilename, fallbackKey, false);
+                        File cached = getOrDownloadArtifact(Bob.ARTIFACTS_URL, platformKey, symbolsFilename, fallbackKey, false);
                         if (cached == null || !cached.exists() || cached.length() == 0) {
                             logger.warning("Symbols not available: %s/%s", platformKey, symbolsFilename);
                             continue;
@@ -118,9 +118,14 @@ public final class EngineArtifactsProvider {
         List<File> binaryFiles = new ArrayList<File>();
         String[] exeSuffixes = platform.getExeSuffixes();
         String defaultDmengineExeName = getDefaultDmengineExeName(variant);
+        OS os = platform.getOsID();
+        // Match the stripped native engines packaged by scripts/copy.sh. Keeping
+        // the same subdirectory in the cache also separates Android symbols.
+        boolean stripped = os == OS.OS_ID_LINUX || os == OS.OS_ID_OSX || os == OS.OS_ID_IOS || os == OS.OS_ID_ANDROID;
         for (String exeSuffix : exeSuffixes) {
             String exeName = platform.getExePrefix() + defaultDmengineExeName + exeSuffix;
-            File file = getOrDownloadArtifact(platform.getPair(), exeName, platform.getOs(), true);
+            String artifactPath = stripped ? "stripped/" + exeName : exeName;
+            File file = getOrDownloadArtifact(artifactsURL, platform.getPair(), artifactPath, platform.getOs(), true);
             if (file == null || !file.exists() || file.length() == 0) {
                 throw new IOException(String.format(
                         "The %s engine for %s (%s) is not available locally and could not be downloaded. " +
@@ -199,14 +204,14 @@ public final class EngineArtifactsProvider {
         return new File(dir, filename);
     }
 
-    private static File getOrDownloadArtifact(String platformKey, String filename, String fallbackPlatformKey, boolean executable) {
+    private static File getOrDownloadArtifact(String artifactsURL, String platformKey, String filename, String fallbackPlatformKey, boolean executable) {
         File cached = getCacheFile(platformKey, filename);
         try {
             if (cached.exists() && cached.length() > 0) {
                 return cached;
             }
-            URL primary = buildArtifactURL(Bob.ARTIFACTS_URL, platformKey, filename);
-            URL fallback = fallbackPlatformKey != null ? buildArtifactURL(Bob.ARTIFACTS_URL, fallbackPlatformKey, filename) : null;
+            URL primary = buildArtifactURL(artifactsURL, platformKey, filename);
+            URL fallback = fallbackPlatformKey != null ? buildArtifactURL(artifactsURL, fallbackPlatformKey, filename) : null;
             downloadWithFallback(primary, fallback, cached, executable);
             if (executable) {
                 cached.setExecutable(true);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/EngineArtifactsProvider.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/EngineArtifactsProvider.java
@@ -122,7 +122,9 @@ public final class EngineArtifactsProvider {
             String exeName = platform.getExePrefix() + defaultDmengineExeName + exeSuffix;
             File file = getOrDownloadArtifact(platform.getPair(), exeName, platform.getOs(), true);
             if (file == null || !file.exists() || file.length() == 0) {
-                throw new IOException(String.format("%s could not be found locally or downloaded, create an application manifest to build the engine remotely.", exeName));
+                throw new IOException(String.format(
+                        "The %s engine for %s (%s) is not available locally and could not be downloaded. " +
+                        "Check your internet connection and try again.", variant, platform.getPair(), exeName));
             }
             binaryFiles.add(file);
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/bundle/HTML5Bundler.java
@@ -367,11 +367,7 @@ public class HTML5Bundler implements IBundler {
         BundleHelper.throwIfCanceled(canceled);
         List<File> binsWasm = ExtenderUtil.getNativeExtensionEngineBinaries(project, platform);
         if (binsWasm == null) {
-            try {
-                binsWasm = Bob.getDefaultDmengineFiles(platform, variant);
-            } catch(IOException e) {
-                System.err.println(String.format("Unable to bundle platform %s: %s", platform, e.getMessage()));
-            }
+            binsWasm = Bob.getDefaultDmengineFiles(platform, variant);
         }
         else {
             logger.info("Using extender binary for WASM");

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3909,10 +3909,9 @@ class Configuration(object):
 
         if u.scheme == 's3':
             bucket = s3.get_bucket(u.netloc)
-            # create redirect so that the old s3 paths still work
-            # s3://d.defold.com/archive/channel/sha1/engine/* -> http://d.defold.com/archive/sha1/engine/*
+            # Keep legacy archive paths working without redirecting HTTPS downloads to HTTP.
             redirect_key = self.get_archive_redirect_key(url)
-            redirect_url = url.replace("s3://", "http://")
+            redirect_url = url.replace("s3://", "https://")
 
             if not self.thread_pool:
                 self.thread_pool = ThreadPool(8)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3681,10 +3681,14 @@ class Configuration(object):
         # * Editor files
         # * Defold SDK files
         # * launcher files, used to launch editor2
-        # * rarely used platforms: armv7-android and x86-win32
+        # * rarely used platforms: armv7-android, x86-win32, wasm_pthread-web,
+        #   x86_64-android and arm64_sim-ios
+        # * arm64-linux vanilla engines (keep native compiler libraries)
         # * headless builds
         pattern = re.compile(
-            r'(^|/)editor(2)*/|/defoldsdk\.zip$|/launcher(\.exe)*$|/(armv7-android|x86-win32)(/|$)|headless'
+            r'(^|/)editor(2)*/|/defoldsdk\.zip$|/launcher(\.exe)*$'
+            r'|/(armv7-android|x86-win32|wasm_pthread-web|x86_64-android|arm64_sim-ios)(/|$)|headless'
+            r'|/arm64-linux/(stripped/)?(lib)?dmengine[^/]*$'
         )
         prefix = s3.get_archive_prefix(self.get_archive_path(), self._git_sha1())
         for obj_summary in bucket.objects.filter(Prefix=prefix):


### PR DESCRIPTION
Download `wasm_pthread-web`, `x86_64-android`, `arm64_sim-ios`, and `arm64-linux` vanilla engine targets on demand to reduce the default Bob and editor package sizes. Bundling for these targets requires an internet connection unless the matching engine is already cached. Failed downloads now provide clearer error messages and connection guidance.

### Technical changes

- Exclude debug and release engines for `wasm_pthread-web`, `x86_64-android`, `arm64_sim-ios`, and `arm64-linux` through the existing archive-sync and release-copy mechanisms.
- Preserve ARM64 Linux compiler libraries and existing local build behavior.
- Include the platform, variant, and filename in failed-download errors, replacing the recommendation to build remotely.
- Verified archive sync and the complete copy script with fixtures. Compiled the error-message change and passed 12 checks covering download failures and cached-engine reuse.