### PR TITLE
Remap shader input & outputs between graphics stages in legacy shader pipeline

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
@@ -400,11 +400,10 @@ public class ShaderCompilePipelineTest {
     }
 
     @Test
-    public void testLegacyRemapsWhiteOverlayShaderStageLocations() throws Exception {
-        // Regression for github.com/defold/defold/issues/13164. The unused first
-        // fragment varying is optimized away after glslang assigns locations,
-        // leaving the two live fragment inputs at locations 1 and 2 while the
-        // corresponding vertex outputs occupy locations 0 and 1.
+    public void testLegacyRemapsStageLocationsAfterUnusedVaryingRemoval() throws Exception {
+        // The unused first fragment varying is optimized away after glslang
+        // assigns locations, leaving the two live fragment inputs at locations
+        // 1 and 2 while the corresponding vertex outputs occupy locations 0 and 1.
         String vsShader =
                 """
                 precision mediump float;
@@ -431,30 +430,22 @@ public class ShaderCompilePipelineTest {
                 #else
                     precision mediump int;
                 #endif
-                varying mediump vec4 position;
+                varying mediump vec4 unused_varying;
                 varying mediump vec2 var_texcoord0;
                 varying lowp vec4 var_color;
                 uniform lowp sampler2D texture_sampler;
                 void main()
                 {
-                    const lowp vec3 tint_color = vec3(1, 1, 1);
-                    const lowp vec4 grayscale_color = vec4(1, 1, 1, 1);
-                    const lowp float brightness = 2.0;
-                    const lowp float contrast = 1.0;
-                    lowp vec4 texture_color = texture2D(texture_sampler, var_texcoord0.xy) * var_color;
-                    lowp vec3 grayscaled_texture = vec3(dot(texture_color, grayscale_color));
-                    lowp vec3 contrasted_texture = (grayscaled_texture.rgb - 1.0) * contrast + texture_color.a * 1.0;
-                    lowp vec3 brightened_texture = contrasted_texture * brightness;
-                    gl_FragColor = vec4(brightened_texture * tint_color, texture_color.a);
+                    gl_FragColor = texture2D(texture_sampler, var_texcoord0.xy) * var_color;
                 }
                 """;
 
         ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModuleDescs = toShaderDescs(vsShader, fsShader);
-        shaderModuleDescs.get(0).resourcePath = "/main/materials/white_overlay/white_overlay.vp";
-        shaderModuleDescs.get(1).resourcePath = "/main/materials/white_overlay/white_overlay.fp";
+        shaderModuleDescs.get(0).resourcePath = "/test/location_remap.vp";
+        shaderModuleDescs.get(1).resourcePath = "/test/location_remap.fp";
 
         ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(
-                "/main/materials/white_overlay/white_overlay",
+                "/test/location_remap",
                 shaderModuleDescs,
                 new ShaderCompilePipeline.Options());
         try {

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/ShaderCompilePipelineTest.java
@@ -400,6 +400,128 @@ public class ShaderCompilePipelineTest {
     }
 
     @Test
+    public void testLegacyRemapsWhiteOverlayShaderStageLocations() throws Exception {
+        // Regression for github.com/defold/defold/issues/13164. The unused first
+        // fragment varying is optimized away after glslang assigns locations,
+        // leaving the two live fragment inputs at locations 1 and 2 while the
+        // corresponding vertex outputs occupy locations 0 and 1.
+        String vsShader =
+                """
+                precision mediump float;
+                precision highp int;
+                uniform mediump mat4 view_proj;
+                attribute mediump vec4 position;
+                attribute mediump vec2 texcoord0;
+                attribute lowp vec4 color;
+                varying mediump vec2 var_texcoord0;
+                varying lowp vec4 var_color;
+                void main()
+                {
+                    var_texcoord0 = texcoord0;
+                    var_color = color;
+                    gl_Position = view_proj * vec4(position.xyz, 1.0);
+                }
+                """;
+
+        String fsShader =
+                """
+                precision mediump float;
+                #ifdef GL_FRAGMENT_PRECISION_HIGH
+                    precision highp int;
+                #else
+                    precision mediump int;
+                #endif
+                varying mediump vec4 position;
+                varying mediump vec2 var_texcoord0;
+                varying lowp vec4 var_color;
+                uniform lowp sampler2D texture_sampler;
+                void main()
+                {
+                    const lowp vec3 tint_color = vec3(1, 1, 1);
+                    const lowp vec4 grayscale_color = vec4(1, 1, 1, 1);
+                    const lowp float brightness = 2.0;
+                    const lowp float contrast = 1.0;
+                    lowp vec4 texture_color = texture2D(texture_sampler, var_texcoord0.xy) * var_color;
+                    lowp vec3 grayscaled_texture = vec3(dot(texture_color, grayscale_color));
+                    lowp vec3 contrasted_texture = (grayscaled_texture.rgb - 1.0) * contrast + texture_color.a * 1.0;
+                    lowp vec3 brightened_texture = contrasted_texture * brightness;
+                    gl_FragColor = vec4(brightened_texture * tint_color, texture_color.a);
+                }
+                """;
+
+        ArrayList<ShaderCompilePipeline.ShaderModuleDesc> shaderModuleDescs = toShaderDescs(vsShader, fsShader);
+        shaderModuleDescs.get(0).resourcePath = "/main/materials/white_overlay/white_overlay.vp";
+        shaderModuleDescs.get(1).resourcePath = "/main/materials/white_overlay/white_overlay.fp";
+
+        ShaderCompilePipeline pipeline = ShaderProgramBuilder.newShaderPipeline(
+                "/main/materials/white_overlay/white_overlay",
+                shaderModuleDescs,
+                new ShaderCompilePipeline.Options());
+        try {
+            assertTrue(pipeline instanceof ShaderCompilePipelineLegacy);
+
+            SPIRVReflector reflectorVs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_VERTEX);
+            SPIRVReflector reflectorFs = pipeline.getReflectionData(ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT);
+            assertEquals(0, Byte.toUnsignedInt(getShaderResource(reflectorVs, "var_texcoord0").location));
+            assertEquals(0, Byte.toUnsignedInt(getShaderResource(reflectorFs, "var_texcoord0").location));
+            assertEquals(1, Byte.toUnsignedInt(getShaderResource(reflectorVs, "var_color").location));
+            assertEquals(1, Byte.toUnsignedInt(getShaderResource(reflectorFs, "var_color").location));
+
+            // Verify that crossCompile returns the remapped module, not the original
+            // per-stage bytes emitted by glslang.
+            Shaderc.ShaderCompileResult fragmentSpirv = pipeline.crossCompile(
+                    ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT,
+                    ShaderDesc.Language.LANGUAGE_SPIRV);
+            long fragmentContext = ShadercJni.NewShaderContext(
+                    Shaderc.ShaderStage.SHADER_STAGE_FRAGMENT.getValue(),
+                    fragmentSpirv.data);
+            try {
+                SPIRVReflector serializedReflector = new SPIRVReflector(fragmentContext, ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT);
+                assertEquals(0, Byte.toUnsignedInt(getShaderResource(serializedReflector, "var_texcoord0").location));
+                assertEquals(1, Byte.toUnsignedInt(getShaderResource(serializedReflector, "var_color").location));
+            } finally {
+                ShadercJni.DeleteShaderContext(fragmentContext);
+            }
+        } finally {
+            ShaderCompilePipeline.destroyShaderPipeline(pipeline);
+        }
+    }
+
+    @Test
+    public void testLegacyRejectsCrossStageVaryingTypeMismatch() throws Exception {
+        String vsShader =
+                """
+                attribute vec4 position;
+                varying vec2 var_texcoord0;
+                void main()
+                {
+                    var_texcoord0 = position.xy;
+                    gl_Position = position;
+                }
+                """;
+        String fsShader =
+                """
+                varying vec3 var_texcoord0;
+                void main()
+                {
+                    gl_FragColor = vec4(var_texcoord0, 1.0);
+                }
+                """;
+
+        ShaderCompilePipelineLegacy pipeline = new ShaderCompilePipelineLegacy("testLegacyStageValidation");
+        try {
+            try {
+                ShaderCompilePipeline.createShaderPipeline(pipeline, toShaderDescs(vsShader, fsShader), new ShaderCompilePipeline.Options());
+                fail("Expected cross-stage varying validation to fail");
+            } catch (CompileExceptionError e) {
+                assertTrue(e.getMessage().contains("Shader stage type mismatch for 'var_texcoord0'"));
+            }
+        } finally {
+            ShaderCompilePipeline.destroyShaderPipeline(pipeline);
+        }
+    }
+
+    @Test
     public void testFailingCrossCompilation() throws IOException, CompileExceptionError {
         String fsShader =
                 """

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipeline.java
@@ -375,9 +375,6 @@ public class ShaderCompilePipeline {
             return;
         }
 
-        ShaderModule vertexModule = null;
-        ShaderModule fragmentModule = null;
-
         // Generate SPIR-V for each module
         for (ShaderModule module : this.shaderModules) {
             String baseName = this.pipelineName + "." + ShaderTypeToSpirvStage(module.desc.type);
@@ -402,7 +399,18 @@ public class ShaderCompilePipeline {
             module.spirvContext = ShadercJni.NewShaderContext(ToShadercShaderStageValue(module.desc.type), FileUtils.readFileToByteArray(fileOutSpvOpt));
             module.spirvReflector = new SPIRVReflector(module.spirvContext, module.desc.type);
             module.shaderInfo = ShaderUtil.Common.getShaderInfo(module.desc.source);
+        }
 
+        postProcessGraphicsStages(true);
+    }
+
+    // SPIR-V modules are compiled one stage at a time. Reconcile and validate the
+    // graphics-stage interface before any backend consumes those modules.
+    protected void postProcessGraphicsStages(boolean mergeStageResources) throws IOException, CompileExceptionError {
+        ShaderModule vertexModule = null;
+        ShaderModule fragmentModule = null;
+
+        for (ShaderModule module : this.shaderModules) {
             if (module.desc.type == ShaderDesc.ShaderType.SHADER_TYPE_VERTEX) {
                 vertexModule = module;
             } else if (module.desc.type == ShaderDesc.ShaderType.SHADER_TYPE_FRAGMENT) {
@@ -410,7 +418,6 @@ public class ShaderCompilePipeline {
             }
         }
 
-        // Potentially post-fix the modules so they are compatible in runtime
         if (vertexModule != null && fragmentModule != null) {
             ArrayList<Long> mergedResources = new ArrayList<>();
             long compilerVs = 0;
@@ -422,7 +429,9 @@ public class ShaderCompilePipeline {
             } else {
                 compilerFs = remapFragmentInputsToVertexOutputs(vertexModule, fragmentModule);
             }
-            compilerFs = mergeResources(vertexModule, fragmentModule, compilerFs, mergedResources);
+            if (mergeStageResources) {
+                compilerFs = mergeResources(vertexModule, fragmentModule, compilerFs, mergedResources);
+            }
 
             // If we remapped the input/outputs or the resources, we need to re-generate the spir-v
             if (compilerVs != 0 || compilerFs != 0) {
@@ -445,6 +454,8 @@ public class ShaderCompilePipeline {
                     fragmentModule.spirvReflector.removeResourceByNameHash(mergedResource);
                 }
             }
+
+            validateGraphicsStageInterfaces(vertexModule, fragmentModule);
         }
     }
 
@@ -488,6 +499,42 @@ public class ShaderCompilePipeline {
             }
         }
         return compiler;
+    }
+
+    private void validateGraphicsStageInterfaces(ShaderModule vertexModule, ShaderModule fragmentModule) throws CompileExceptionError {
+        HashMap<String, Shaderc.ShaderResource> outputByName = new HashMap<>();
+        for (Shaderc.ShaderResource output : vertexModule.spirvReflector.getOutputs()) {
+            if (!isBuiltInStageIO(output)) {
+                outputByName.put(output.name, output);
+            }
+        }
+
+        for (Shaderc.ShaderResource input : fragmentModule.spirvReflector.getInputs()) {
+            if (isBuiltInStageIO(input)) {
+                continue;
+            }
+
+            Shaderc.ShaderResource output = outputByName.get(input.name);
+            // Preserve support for legacy shaders with fragment-only varyings.
+            // Cross-stage validation applies to interface entries shared by name.
+            if (output == null) {
+                continue;
+            }
+
+            int outputLocation = Byte.toUnsignedInt(output.location);
+            int inputLocation = Byte.toUnsignedInt(input.location);
+            if (outputLocation != inputLocation) {
+                throw new CompileExceptionError(String.format(
+                        "Shader stage location mismatch for '%s': vertex output location %d in '%s', fragment input location %d in '%s'",
+                        input.name, outputLocation, vertexModule.desc.resourcePath, inputLocation, fragmentModule.desc.resourcePath));
+            }
+
+            if (!SPIRVReflector.AreResourceTypesEqual(vertexModule.spirvReflector, fragmentModule.spirvReflector, output, input)) {
+                throw new CompileExceptionError(String.format(
+                        "Shader stage type mismatch for '%s' at location %d between '%s' and '%s'",
+                        input.name, inputLocation, vertexModule.desc.resourcePath, fragmentModule.desc.resourcePath));
+            }
+        }
     }
 
     private void recompileSpirvModule(ShaderModule module, long compiler) throws IOException, CompileExceptionError {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/shader/ShaderCompilePipelineLegacy.java
@@ -32,7 +32,6 @@ import org.apache.commons.io.FilenameUtils;
 public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
 
     static private class SPIRVCompileResult {
-        public byte[] source;
         public ArrayList<String> compile_warnings = new ArrayList<String>();
         public SPIRVReflector reflector;
     }
@@ -195,9 +194,9 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
         }
 
         moduleLegacy.spirvContext = ShadercJni.NewShaderContext(ToShadercShaderStageValue(moduleLegacy.desc.type), FileUtils.readFileToByteArray(file_out_spv));
+        moduleLegacy.spirvFile = file_out_spv;
 
         res.reflector = new SPIRVReflector(moduleLegacy.spirvContext, shaderType);
-        res.source = FileUtils.readFileToByteArray(file_out_spv);
 
         return res;
     }
@@ -225,6 +224,10 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
             moduleLegacy.spirvResult = compileGLSLToSPIRV(moduleLegacy, this.pipelineName, "", false, this.options.splitTextureSamplers);
             moduleLegacy.spirvReflector = moduleLegacy.spirvResult.reflector;
         }
+
+        // Legacy shaders use plain uniforms for their GLES output, but their SPIR-V
+        // still needs the same cross-stage interface reconciliation as modern shaders.
+        postProcessGraphicsStages(false);
     }
 
     @Override
@@ -236,10 +239,10 @@ public class ShaderCompilePipelineLegacy extends ShaderCompilePipeline {
 
         if (shaderLanguage == ShaderDesc.Language.LANGUAGE_SPIRV) {
             Shaderc.ShaderCompileResult result = new Shaderc.ShaderCompileResult();
-            result.data = module.spirvResult.source;
+            result.data = FileUtils.readFileToByteArray(module.spirvFile);
             return result;
         } else if(shaderLanguage == ShaderDesc.Language.LANGUAGE_WGSL) {
-            String compileResult = compileSPIRVToWGSL(module.desc.resourcePath, shaderType, module.spirvResult.source, this.pipelineName);
+            String compileResult = compileSPIRVToWGSL(module.desc.resourcePath, shaderType, FileUtils.readFileToByteArray(module.spirvFile), this.pipelineName);
 
             Shaderc.ShaderCompileResult result = new Shaderc.ShaderCompileResult();
             result.data = compileResult.getBytes();

--- a/engine/graphics/src/vulkan/graphics_vulkan.cpp
+++ b/engine/graphics/src/vulkan/graphics_vulkan.cpp
@@ -2191,7 +2191,16 @@ bail:
             Pipeline new_pipeline = {};
 
             VkResult res = CreateComputePipeline(vk_device, vk_pipeline_cache, program, &new_pipeline);
-            CHECK_VK_ERROR(res);
+            if (res != VK_SUCCESS || new_pipeline == VK_NULL_HANDLE)
+            {
+                dmLogError("Failed to create Vulkan compute pipeline (result: %d, pipeline hash: %llu, program hash: %llu)",
+                    (int) res, (unsigned long long) pipeline_hash, (unsigned long long) program->m_Hash);
+                if (new_pipeline != VK_NULL_HANDLE)
+                {
+                    vkDestroyPipeline(vk_device, new_pipeline, 0);
+                }
+                return 0;
+            }
 
             if (pipelineCache.Full())
             {
@@ -2239,12 +2248,16 @@ bail:
             vk_scissor.offset.y = 0;
 
             VkResult res = CreateGraphicsPipeline(vk_device, vk_pipeline_cache, vk_scissor, vk_sample_count, pipelineState, program, vertexDeclaration, vertexDeclarationCount, rt, &new_pipeline);
-            if (res == VK_ERROR_INITIALIZATION_FAILED)
+            if (res != VK_SUCCESS || new_pipeline == VK_NULL_HANDLE)
             {
-                dmLogError("Failed to create VkPipeline");
+                dmLogError("Failed to create Vulkan graphics pipeline (result: %d, pipeline hash: %llu, program hash: %llu)",
+                    (int) res, (unsigned long long) pipeline_hash, (unsigned long long) program->m_Hash);
+                if (new_pipeline != VK_NULL_HANDLE)
+                {
+                    vkDestroyPipeline(vk_device, new_pipeline, 0);
+                }
                 return 0;
             }
-            CHECK_VK_ERROR(res);
 
             if (pipelineCache.Full())
             {
@@ -3110,7 +3123,7 @@ bail:
         assert(context->m_DynamicOffsetBufferSize >= num_uniform_buffers);
     }
 
-    static void DrawSetupCompute(VulkanContext* context, VkCommandBuffer vk_command_buffer, ScratchBuffer* scratchBuffer)
+    static bool DrawSetupCompute(VulkanContext* context, VkCommandBuffer vk_command_buffer, ScratchBuffer* scratchBuffer)
     {
         VkDevice vk_device   = context->m_LogicalDevice.m_Device;
         VulkanProgram* program_ptr = context->m_CurrentProgram;
@@ -3124,7 +3137,12 @@ bail:
         CHECK_VK_ERROR(res);
 
         Pipeline* pipeline = GetOrCreateComputePipeline(vk_device, context->m_VkPipelineCache, context->m_PipelineCache, program_ptr);
+        if (!pipeline || *pipeline == VK_NULL_HANDLE)
+        {
+            return false;
+        }
         vkCmdBindPipeline(vk_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, *pipeline);
+        return true;
     }
 
     static bool DrawSetup(VulkanContext* context, VkCommandBuffer vk_command_buffer, ScratchBuffer* scratchBuffer, DeviceBuffer* indexBuffer, Type indexBufferType)
@@ -3223,7 +3241,7 @@ bail:
             pipeline_state_draw, context->m_PipelineCache,
             program_ptr, current_rt, vx_declarations, num_vx_buffers);
 
-        if (!pipeline)
+        if (!pipeline || *pipeline == VK_NULL_HANDLE)
         {
             return false;
         }
@@ -3301,7 +3319,11 @@ bail:
         const uint8_t ix = context->m_CurrentFrameInFlight;
         VkCommandBuffer vk_command_buffer = context->m_MainCommandBuffers[ix];
         context->m_PipelineState.m_PrimtiveType = prim_type;
-        DrawSetup(context, vk_command_buffer, &context->m_MainScratchBuffers[ix], 0, TYPE_BYTE);
+        if (!DrawSetup(context, vk_command_buffer, &context->m_MainScratchBuffers[ix], 0, TYPE_BYTE))
+        {
+            dmLogError("Failed setup draw state");
+            return;
+        }
         vkCmdDraw(vk_command_buffer, count, dmMath::Max((uint32_t) 1, instance_count), first, 0);
     }
 
@@ -3320,7 +3342,11 @@ bail:
 
         const uint8_t ix = context->m_CurrentFrameInFlight;
         VkCommandBuffer vk_command_buffer = context->m_MainCommandBuffers[ix];
-        DrawSetupCompute(context, vk_command_buffer, &context->m_MainScratchBuffers[ix]);
+        if (!DrawSetupCompute(context, vk_command_buffer, &context->m_MainScratchBuffers[ix]))
+        {
+            dmLogError("Failed setup compute dispatch state");
+            return;
+        }
         vkCmdDispatch(vk_command_buffer, group_count_x, group_count_y, group_count_z);
     }
 


### PR DESCRIPTION
Legacy shaders now keep vertex outputs and fragment inputs aligned after unused varyings are removed during compilation. Vulkan draw and compute commands also stop safely when pipeline creation fails instead of attempting to bind an invalid pipeline.

Fix https://github.com/defold/defold/issues/13164

### Technical changes

- Apply cross-stage input/output remapping and validation to the legacy shader pipeline.
- Regenerate and serialize remapped SPIR-V modules for downstream compilation.
- Report shader compilation errors when matching vertex and fragment varyings have incompatible types or locations.
- Validate Vulkan pipeline creation results and handles before caching or binding them.
- Abort draw and compute dispatch setup safely with diagnostic logging when pipeline creation fails.
- Add Bob tests for location remapping after unused varying removal and cross-stage varying type mismatches.