### PR TITLE
Maintanence: Fix Bob Java and Gradle deprecations

### DIFF
--- a/com.dynamo.cr/com.dynamo.cr.bob.test/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/build.gradle
@@ -1,5 +1,8 @@
 apply from: '../com.dynamo.cr.bob/build.gradle'
 
+def bobJar = file("${project.bobDir}/dist/bob.jar")
+def testClass = project.findProperty('testClass')?.toString()
+
 def testClassesDir = file("$testDir/build")
 def testTmpDir = file("$testDir/tmp")
 def DM_BOB_BUNDLERTEST_ONLY_HOST = project.hasProperty('DM_BOB_BUNDLERTEST_ONLY_HOST') ? project.property('DM_BOB_BUNDLERTEST_ONLY_HOST') : ''
@@ -30,7 +33,7 @@ task compileTest(type: JavaCompile, dependsOn: distBob) {
     options.compilerArgs << '-g'
 
     doFirst {
-        if (!file("$project.bobDir/dist/bob.jar").exists()) {
+        if (!bobJar.exists()) {
             throw new RuntimeException("bob.jar is missing")
         }
         mkdir testClassesDir
@@ -70,10 +73,10 @@ task testJar(type: Test, dependsOn: createTestJar) {
 
     testLogging {
         events 'passed', 'skipped', 'failed', 'standardOut'
-        exceptionFormat 'short'
-        showExceptions true
-        showCauses true
-        showStackTraces true
+        exceptionFormat = 'short'
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
     }
 
     classpath = files(configurations.testClasspath, "${project.bobDir}/dist/bob.jar", "${testTmpDir}/bob-tests.jar")
@@ -89,17 +92,17 @@ task runSingleTest(type: Test, dependsOn: createTestJar) {
 
     testLogging {
         events 'passed', 'skipped', 'failed', 'standardOut'
-        exceptionFormat 'short'
-        showExceptions true
-        showCauses true
-        showStackTraces true
+        exceptionFormat = 'short'
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
     }
 
     classpath = files(configurations.testClasspath, "${project.bobDir}/dist/bob.jar", "${testTmpDir}/bob-tests.jar")
     testClassesDirs = files(testClassesDir).asFileTree.matching {
         //provide a test class name with -PtestClass=com.example.MyTestClass to ./gradlew if run from terminal
-        if (project.hasProperty('testClass')) {
-            include "**/${project.testClass.replaceAll('\\.', '/')}.class"
+        if (testClass != null) {
+            include "**/${testClass.replaceAll('\\.', '/')}.class"
         } else if (System.getProperty('idea.active') != null) {
             // Specify needed class here if run from idea
             def test_class = "com.dynamo.bob.pipeline.ShaderProgramBuilderTest"

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/cache/test/ResourceCacheTest.java
@@ -16,8 +16,10 @@ package com.dynamo.bob.cache.test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -67,6 +69,19 @@ public class ResourceCacheTest {
 		resourceCache.put(key, data);
 		assertTrue(resourceCache.contains(key));
 		assertArrayEquals(data, resourceCache.get(key));
+	}
+
+	@Test
+	public void testInvalidRemoteCacheUrl() throws IOException {
+		for (String remoteUrl : new String[] { "relative/path", "http://[invalid", "http://localhost/%invalid" }) {
+			resourceCache.init(cacheDir.toString(), remoteUrl);
+			try {
+				resourceCache.get("somekey");
+				fail("Expected a malformed remote cache URL to throw an IOException");
+			} catch (MalformedURLException e) {
+				assertTrue(e.getCause() instanceof IllegalArgumentException);
+			}
+		}
 	}
 
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BuilderUtilTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/pipeline/BuilderUtilTest.java
@@ -21,9 +21,11 @@ import org.junit.Test;
 
 import com.dynamo.bob.fs.ResourceUtil;
 
+// These tests intentionally exercise the legacy extension compatibility API.
 public class BuilderUtilTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testReplaceExtCompatibilityShim() {
         boolean oldMinification = ResourceUtil.isMinificationEnabled();
         try {
@@ -36,6 +38,7 @@ public class BuilderUtilTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testReplaceExtCompatibilityShimWithMinification() {
         final String inExt = ".compat_material_tmp";
         final String outExt = ".compat_materialc_tmp";

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/test/JBobTest.java
@@ -14,16 +14,18 @@
 
 package com.dynamo.bob.test;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.matchers.JUnitMatchers.hasItem;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -66,6 +68,15 @@ public class JBobTest {
 
     @BuilderParams(name = "InCopyBuilderMulti", inExts = ".in2", outExt = ".out")
     public static class InCopyBuilderMulti extends InCopyBuilder {}
+
+    @BuilderParams(name = "ConstructorException", inExts = ".in_constructor_error", outExt = ".out")
+    public static class ConstructorExceptionBuilder extends CopyBuilder {
+        static final CompileExceptionError ERROR = new CompileExceptionError("Failed to construct builder");
+
+        public ConstructorExceptionBuilder() throws CompileExceptionError {
+            throw ERROR;
+        }
+    }
 
     @BuilderParams(name = "CBuilder", inExts = ".c", outExt = ".o")
     public static class CBuilder extends CopyBuilder {
@@ -215,8 +226,8 @@ public class JBobTest {
             @Override
             public java.util.Enumeration<URL> getResources(String name) throws IOException {
                 return Collections.enumeration(Arrays.asList(
-                        new URL("jar:" + validJarPath.toUri().toURL() + "!/" + name),
-                        new URL("jar:" + missingJarPath.toUri().toURL() + "!/" + name)));
+                        URI.create("jar:" + validJarPath.toUri() + "!/" + name).toURL(),
+                        URI.create("jar:" + missingJarPath.toUri() + "!/" + name).toURL()));
             }
         };
 
@@ -436,6 +447,17 @@ public class JBobTest {
         project.setInputs(Arrays.asList("test.in_ce"));
         // build
         build();
+    }
+
+    @Test
+    public void testConstructorCompileError() throws Exception {
+        fileSystem.addFile("test.in_constructor_error", "test".getBytes());
+        try {
+            project.createTask(project.getResource("test.in_constructor_error"), ConstructorExceptionBuilder.class);
+            fail("Expected the builder constructor to fail");
+        } catch (CompileExceptionError e) {
+            assertSame(ConstructorExceptionBuilder.ERROR, e);
+        }
     }
 
     @Test

--- a/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/ConvexHull2DTest.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob.test/src/com/dynamo/bob/tile/test/ConvexHull2DTest.java
@@ -17,7 +17,7 @@ package com.dynamo.bob.tile.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItem;
 
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;

--- a/com.dynamo.cr/com.dynamo.cr.bob/basic.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/basic.gradle
@@ -47,7 +47,7 @@ ext {
     ]
 }
 
-gradle.taskGraph.whenReady { taskGraph ->
+def configureBuildTools = {
     // Determine Python executable
     def pythonExec = null
     def pythonCandidates = []
@@ -109,6 +109,8 @@ gradle.taskGraph.whenReady { taskGraph ->
         throw e
     }
 }
+
+configureBuildTools()
 
 task getGitRevision {
     ext.gitRevision = ""

--- a/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
+++ b/com.dynamo.cr/com.dynamo.cr.bob/build.gradle
@@ -26,6 +26,15 @@ apply plugin: 'java'
 gradle.startParameter.parallelProjectExecutionEnabled = true
 apply from: '../com.dynamo.cr.bob/basic.gradle'
 
+// Capture build settings during configuration; task actions must not access Task.project.
+def bobDir = project.bobDir
+def classesDir = project.classesDir
+def dynamoHome = file(project.dynamoHome)
+def hostPlatform = project.hostPlatform
+def python = project.python
+def keepBobUncompressed = project.hasProperty('keep-bob-uncompressed')
+def gradleVersion = gradle.gradleVersion
+
 allprojects {
     tasks.withType(Jar) {
         exclude('tmp/**', 'reports/**')
@@ -47,24 +56,24 @@ allprojects {
 
 repositories {
     flatDir {
-        dirs 'lib', "${project.bobDir}/lib", "${project.bobDir}/lib/aws"
+        dirs 'lib', "${bobDir}/lib", "${bobDir}/lib/aws"
     }
 }
 
 def bobLightDependencyJars = ['dlib.jar', 'fontrenderer.jar', 'modelimporter.jar', 'texturecompiler.jar', 'shaderc.jar']
 
 dependencies {
-    implementation fileTree(dir: "${project.bobDir}/lib", include: '*.jar')
-    implementation fileTree(dir: "${project.bobDir}/lib/aws", include: '*.jar')
+    implementation fileTree(dir: "${bobDir}/lib", include: '*.jar')
+    implementation fileTree(dir: "${bobDir}/lib/aws", include: '*.jar')
 }
 
 task cleanDirs(type: Delete) {
-    delete project.classesDir
-    delete file("${project.bobDir}/generated")
-    delete file("${project.bobDir}/dist")
-    delete file("${project.bobDir}/tmp")
-    delete file("${project.bobDir}/target")
-    delete file("${project.bobDir}/lib/luajit-share.zip")
+    delete classesDir
+    delete file("${bobDir}/generated")
+    delete file("${bobDir}/dist")
+    delete file("${bobDir}/tmp")
+    delete file("${bobDir}/target")
+    delete file("${bobDir}/lib/luajit-share.zip")
 }
 
 clean.dependsOn cleanDirs
@@ -80,7 +89,7 @@ gradle.projectsEvaluated {
         tasks.create(name: protoTaskName, type: Exec) {
             group = 'build'
             inputs.file(protoFilePath)
-            outputs.dir("${project.bobDir}/generated")
+            outputs.dir("${bobDir}/generated")
             doFirst {
                 if (!protoDir.exists()) {
                     throw new RuntimeException("Directory '${protoDir}' does not exist")
@@ -88,12 +97,12 @@ gradle.projectsEvaluated {
                 if (!protoFilePath.exists()) {
                     throw new RuntimeException("File '${protoFilePath}' does not exist")
                 }
-                mkdir "${project.bobDir}/generated"
-                if (!project.hostPlatform) {
+                mkdir "${bobDir}/generated"
+                if (!hostPlatform) {
                     throw new RuntimeException("hostPlatform is not set. Make sure 'getHostPlatform' task is executed.")
                 }
-                commandLine "${project.dynamoHome}/ext/bin/${project.hostPlatform}/protoc", "--java_out=${project.bobDir}/generated",
-                        "-I${protoDir}", "-I${project.dynamoHome}/ext/include", "-I../../engine/gameobject/proto",
+                commandLine "${dynamoHome}/ext/bin/${hostPlatform}/protoc", "--java_out=${bobDir}/generated",
+                        "-I${protoDir}", "-I${dynamoHome}/ext/include", "-I../../engine/gameobject/proto",
                         "-I../../engine/script/src", "-I../../engine/ddf/src", "-I../../engine/graphics/proto", "${protoFilePath}"
             }
         }
@@ -111,19 +120,17 @@ task proto(type: Exec) {
     def protoDir = project.findProperty('protoDir') ?: ''
     def protoFile = project.findProperty('protoFile') ?: ''
     inputs.file("${protoDir}/${protoFile}")
-    outputs.dir("${project.bobDir}/generated")
+    outputs.dir("${bobDir}/generated")
     doFirst {
         if (!protoDir || !protoFile) {
             throw new RuntimeException("Properties 'protoDir' and 'protoFile' must be specified")
         }
-        mkdir "${project.bobDir}/generated"
-    }
-    doLast {
-        if (!project.hostPlatform) {
+        mkdir "${bobDir}/generated"
+        if (!hostPlatform) {
             throw new RuntimeException("hostPlatform is not set. Make sure 'getHostPlatform' task is executed.")
         }
-        commandLine "${project.dynamoHome}/ext/bin/${project.hostPlatform}/protoc", "--java_out=${project.bobDir}/generated",
-                "-I${protoDir}", "-I${project.dynamoHome}/ext/include", "-I../../engine/gameobject/proto",
+        commandLine "${dynamoHome}/ext/bin/${hostPlatform}/protoc", "--java_out=${bobDir}/generated",
+                "-I${protoDir}", "-I${dynamoHome}/ext/include", "-I../../engine/gameobject/proto",
                 "-I../../engine/script/src", "-I../../engine/ddf/src", "-I../../engine/graphics/proto", "${protoDir}/${protoFile}"
     }
 }
@@ -131,17 +138,17 @@ task proto(type: Exec) {
 sourceSets {
     main {
         java {
-            srcDirs = ["${project.bobDir}/src",
-                       "${project.bobDir}/generated"]
+            srcDirs = ["${bobDir}/src",
+                       "${bobDir}/generated"]
         }
     }
 }
 
-def bobGitRevision = "git -C ${project.bobDir} log --pretty=%H -n1".execute().text.trim()
+def bobGitRevision = "git -C ${bobDir} log --pretty=%H -n1".execute().text.trim()
 def privateBobPluginModules = []
 def targetPlatform = (project.findProperty('target-platform') ?: '').toString()
 def privatePlatformRoot = ''
-def platformsConfigFile = file("${project.bobDir}/../../.defold-platforms")
+def platformsConfigFile = file("${bobDir}/../../.defold-platforms")
 if (targetPlatform && platformsConfigFile.exists()) {
     def platformsConfig = new JsonSlurper().parse(platformsConfigFile)
     def platformConfig = platformsConfig[targetPlatform]
@@ -196,12 +203,12 @@ def readGitRevision = { String repositoryRoot ->
 def bobBuildContext = [
         "bobRevision=${bobGitRevision}",
         "targetPlatform=${targetPlatform}",
-        "dynamoHome=${file(project.dynamoHome).canonicalPath}",
+        "dynamoHome=${file(dynamoHome).canonicalPath}",
         "privateRoot=${privatePlatformRoot}",
         "privateRevision=${readGitRevision(privatePlatformRoot)}",
         "privatePlugins=${privateBobPluginModules.collect { "${it.name}:${it.jarName}" }.sort().join(',')}"
 ].join('\n') + '\n'
-def bobBuildContextFile = file("${project.bobDir}/build/bob-build-context.txt")
+def bobBuildContextFile = file("${bobDir}/build/bob-build-context.txt")
 
 task prepareBobBuildContext {
     inputs.property('buildContext', bobBuildContext)
@@ -211,13 +218,13 @@ task prepareBobBuildContext {
         def previousContext = bobBuildContextFile.exists() ? bobBuildContextFile.getText('UTF-8') : ''
         if (previousContext != bobBuildContext) {
             logger.lifecycle("Bob build context changed; invalidating shared generated output")
-            delete project.classesDir,
-                    file("${project.bobDir}/generated"),
-                    file("${project.bobDir}/dist"),
-                    file("${project.bobDir}/tmp"),
-                    file("${project.bobDir}/target"),
-                    file("${project.bobDir}/build/private_plugins"),
-                    file("${project.bobDir}/lib/luajit-share.zip")
+            delete classesDir,
+                    file("${bobDir}/generated"),
+                    file("${bobDir}/dist"),
+                    file("${bobDir}/tmp"),
+                    file("${bobDir}/target"),
+                    file("${bobDir}/build/private_plugins"),
+                    file("${bobDir}/lib/luajit-share.zip")
         }
         bobBuildContextFile.parentFile.mkdirs()
         bobBuildContextFile.setText(bobBuildContext, 'UTF-8')
@@ -228,26 +235,26 @@ execProtoTasks.dependsOn prepareBobBuildContext
 
 task copyDependencies {
     dependsOn prepareBobBuildContext
-    inputs.file("${project.bobDir}/engine_version_generator.py")
+    inputs.file("${bobDir}/engine_version_generator.py")
     inputs.file("../../VERSION")
     inputs.property("gitRevision", bobGitRevision)
-    inputs.files(bobLightDependencyJars.collect { "${project.dynamoHome}/share/java/${it}" })
-    outputs.file("${project.bobDir}/src/com/dynamo/bob/archive/EngineVersion.java")
-    outputs.files(bobLightDependencyJars.collect { "${project.bobDir}/lib/${it}" })
+    inputs.files(bobLightDependencyJars.collect { "${dynamoHome}/share/java/${it}" })
+    outputs.file("${bobDir}/src/com/dynamo/bob/archive/EngineVersion.java")
+    outputs.files(bobLightDependencyJars.collect { "${bobDir}/lib/${it}" })
 
     doLast {
         services.get(org.gradle.process.ExecOperations).exec {
-            workingDir project.bobDir
-            commandLine project.python, "${project.bobDir}/engine_version_generator.py"
+            workingDir bobDir
+            commandLine python, "${bobDir}/engine_version_generator.py"
         }
         copy {
-            from fileTree("${project.dynamoHome}/share/java") {
+            from fileTree("${dynamoHome}/share/java") {
                 include bobLightDependencyJars
             }
-            into "${project.bobDir}/lib"
+            into "${bobDir}/lib"
         }
         bobLightDependencyJars.each { jar ->
-            if (!file("${project.bobDir}/lib/$jar").exists()) {
+            if (!file("${bobDir}/lib/$jar").exists()) {
                 throw new RuntimeException("$jar is missing")
             }
         }
@@ -255,38 +262,38 @@ task copyDependencies {
 }
 
 task compileGenerated(type: JavaCompile, dependsOn: [execProtoTasks, copyDependencies]) {
-    mkdir project.classesDir
-    source = fileTree("${project.bobDir}/generated")
-    destinationDirectory = project.classesDir
+    mkdir classesDir
+    source = fileTree("${bobDir}/generated")
+    destinationDirectory = classesDir
     include '**/*.java'
     classpath = sourceSets.main.compileClasspath
     options.encoding = 'UTF-8'
     options.compilerArgs << '-g'
-    outputs.dir(project.classesDir)
+    outputs.dir(classesDir)
 }
 
 task compileSrc(type: JavaCompile, dependsOn: [compileGenerated, copyDependencies]) {
     source = sourceSets.main.java
-    destinationDirectory = project.classesDir
+    destinationDirectory = classesDir
     include '**'
     exclude '**/XBoxBundler.java'
     exclude '**/XBoxShaderCompiler.java'
     classpath = sourceSets.main.compileClasspath
     options.encoding = 'UTF-8'
     options.compilerArgs << '-g'
-    outputs.dir(project.classesDir)
+    outputs.dir(classesDir)
 }
 
 privateBobPluginModules.each { module ->
     def taskSuffix = module.name.replaceAll(/[^A-Za-z0-9]/, '_')
-    def pluginClassesDir = file("${project.bobDir}/build/private_plugins/${module.name}")
+    def pluginClassesDir = file("${bobDir}/build/private_plugins/${module.name}")
 
     def compileTask = tasks.create(name: "compilePrivatePlugin_${taskSuffix}", type: JavaCompile) {
         dependsOn compileSrc, 'compileBobLight'
         source = fileTree(module.sourceDir)
         destinationDirectory = pluginClassesDir
         include '**/*.java'
-        classpath = files(project.classesDir) + sourceSets.main.compileClasspath
+        classpath = files(classesDir) + sourceSets.main.compileClasspath
         options.encoding = 'UTF-8'
         options.compilerArgs << '-g'
         outputs.dir(pluginClassesDir)
@@ -295,10 +302,10 @@ privateBobPluginModules.each { module ->
     def jarTask = tasks.create(name: "createPrivatePluginJar_${taskSuffix}", type: Jar) {
         dependsOn compileTask
         archiveFileName = module.jarName
-        destinationDirectory = file("${project.bobDir}/dist/plugins")
+        destinationDirectory = file("${bobDir}/dist/plugins")
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         from pluginClassesDir
-        outputs.file("${project.bobDir}/dist/plugins/${module.jarName}")
+        outputs.file("${bobDir}/dist/plugins/${module.jarName}")
     }
 
     privateBobPluginJarTasks << jarTask
@@ -308,8 +315,8 @@ task installPrivatePluginJars(dependsOn: privateBobPluginJarTasks) {
     doLast {
         privateBobPluginModules.each { module ->
             copy {
-                from "${project.bobDir}/dist/plugins/${module.jarName}"
-                into "${project.dynamoHome}/share/java/plugins"
+                from "${bobDir}/dist/plugins/${module.jarName}"
+                into "${dynamoHome}/share/java/plugins"
             }
         }
     }
@@ -320,18 +327,18 @@ task installPrivatePlugins(dependsOn: 'installBobLight') {
 
 task createLuaJitShareZip(type: Zip, dependsOn: [compileSrc, compileGenerated]) {
     archiveFileName = 'luajit-share.zip'
-    destinationDirectory = file("${project.bobDir}/lib")
+    destinationDirectory = file("${bobDir}/lib")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-    from("${project.dynamoHome}/ext/share/luajit") {
+    from("${dynamoHome}/ext/share/luajit") {
         into 'luajit'
     }
 
-    inputs.dir("${project.dynamoHome}/ext/share/luajit")
-    outputs.file("${project.bobDir}/lib/luajit-share.zip")
+    inputs.dir("${dynamoHome}/ext/share/luajit")
+    outputs.file("${bobDir}/lib/luajit-share.zip")
 }
 
-def bobLightResourceRoot = file("${project.bobDir}/src")
+def bobLightResourceRoot = file("${bobDir}/src")
 def bobLightResourceFiles = fileTree(bobLightResourceRoot) {
     exclude '**/*.java'
 }
@@ -343,59 +350,59 @@ def vkQualityNativeLibraries = [
 
 task compileBobLight(dependsOn: [compileSrc, createLuaJitShareZip]) {
     inputs.files(bobLightResourceFiles)
-    inputs.dir("${project.dynamoHome}/ext/bin")
-    inputs.dir("${project.dynamoHome}/ext/share/luajit")
+    inputs.dir("${dynamoHome}/ext/bin")
+    inputs.dir("${dynamoHome}/ext/share/luajit")
     inputs.files(fileTree("../../packages") {
         include "luajit-2.1.0-3e223cb-*.tar.gz"
     })
-    inputs.files(fileTree("${project.dynamoHome}/lib") {
+    inputs.files(fileTree("${dynamoHome}/lib") {
         include '**/*texc_shared*',
                 '**/*modelc_shared*',
                 '**/*shaderc_shared*',
                 '**/*fontc_shared*'
         exclude '**/*dSYM.zip'
     })
-    inputs.file("${project.dynamoHome}/ext/share/java/bundletool-all.jar").optional()
-    inputs.files(fileTree("${project.dynamoHome}/ext/lib") {
+    inputs.file("${dynamoHome}/ext/share/java/bundletool-all.jar").optional()
+    inputs.files(fileTree("${dynamoHome}/ext/lib") {
         include vkQualityNativeLibraries
     })
     outputs.dirs(
-            "${project.bobDir}/libexec",
-            "${project.bobDir}/lib/x86_64-macos",
-            "${project.bobDir}/lib/arm64-macos",
-            "${project.bobDir}/lib/x86_64-linux",
-            "${project.bobDir}/lib/arm64-linux",
-            "${project.bobDir}/lib/x86_64-win32"
+            "${bobDir}/libexec",
+            "${bobDir}/lib/x86_64-macos",
+            "${bobDir}/lib/arm64-macos",
+            "${bobDir}/lib/x86_64-linux",
+            "${bobDir}/lib/arm64-linux",
+            "${bobDir}/lib/x86_64-win32"
     )
     outputs.files(bobLightResourceFiles.collect { resource ->
-        file("${project.classesDir}/${bobLightResourceRoot.toPath().relativize(resource.toPath()).toString()}")
+        file("${classesDir}/${bobLightResourceRoot.toPath().relativize(resource.toPath()).toString()}")
     })
 
     doLast {
         def missingVkQualityLibraries = vkQualityNativeLibraries.findAll { relativePath ->
-            !file("${project.dynamoHome}/ext/lib/${relativePath}").exists()
+            !file("${dynamoHome}/ext/lib/${relativePath}").exists()
         }
         if (!missingVkQualityLibraries.isEmpty()) {
             throw new RuntimeException("Required VkQuality native libraries are missing from DYNAMO_HOME: ${missingVkQualityLibraries.collect { "ext/lib/${it}" }.join(', ')}")
         }
 
-        def bundletoolJar = file("${project.dynamoHome}/ext/share/java/bundletool-all.jar")
+        def bundletoolJar = file("${dynamoHome}/ext/share/java/bundletool-all.jar")
         if (bundletoolJar.exists()) {
             copy {
                 from bundletoolJar
-                into "${project.bobDir}/libexec"
+                into "${bobDir}/libexec"
             }
         }
 
         copy {
-            from fileTree("${project.dynamoHome}/ext/lib") {
+            from fileTree("${dynamoHome}/ext/lib") {
                 include vkQualityNativeLibraries
             }
-            into "${project.bobDir}/libexec"
+            into "${bobDir}/libexec"
         }
 
         def missingPackagedVkQualityLibraries = vkQualityNativeLibraries.findAll { relativePath ->
-            !file("${project.bobDir}/libexec/${relativePath}").exists()
+            !file("${bobDir}/libexec/${relativePath}").exists()
         }
         if (!missingPackagedVkQualityLibraries.isEmpty()) {
             throw new RuntimeException("Required VkQuality native libraries were not copied into Bob: ${missingPackagedVkQualityLibraries.collect { "libexec/${it}" }.join(', ')}")
@@ -411,10 +418,10 @@ task compileBobLight(dependsOn: [compileSrc, createLuaJitShareZip]) {
 
         platformFiles.forEach { platform, files ->
             copy {
-                from fileTree("${project.dynamoHome}/ext/bin/$platform") {
+                from fileTree("${dynamoHome}/ext/bin/$platform") {
                     include files.collect { it.toString() }
                 }
-                into "${project.bobDir}/libexec/$platform"
+                into "${bobDir}/libexec/$platform"
             }
         }
         def defaultTarName = 'luajit-2.1.0-3e223cb'
@@ -429,7 +436,7 @@ task compileBobLight(dependsOn: [compileSrc, createLuaJitShareZip]) {
         tarFiles.forEach { platform, config ->
             copy {
                 from tarTree(resources.gzip(file("../../packages/${config.name}-${platform}.tar.gz")))
-                into "${project.bobDir}/libexec/${platform}"
+                into "${bobDir}/libexec/${platform}"
                 eachFile { fileCopyDetails ->
                     fileCopyDetails.path = fileCopyDetails.path.replaceFirst("^bin/$platform/", "")
                 }
@@ -439,7 +446,7 @@ task compileBobLight(dependsOn: [compileSrc, createLuaJitShareZip]) {
 
         copy {
             from bobLightResourceFiles
-            into project.classesDir
+            into classesDir
         }
 
         def sharedLibs = [
@@ -452,11 +459,11 @@ task compileBobLight(dependsOn: [compileSrc, createLuaJitShareZip]) {
 
         sharedLibs.forEach { platform, includePatterns ->
             copy {
-                from fileTree("${project.dynamoHome}/lib") {
+                from fileTree("${dynamoHome}/lib") {
                     include includePatterns
                     exclude '**/*dSYM.zip'
                 }
-                into "${project.bobDir}/lib/${platform}"
+                into "${bobDir}/lib/${platform}"
                 eachFile { fileCopyDetails ->
                     fileCopyDetails.path = fileCopyDetails.path.replaceFirst("^${platform}/", "")
                 }
@@ -470,19 +477,19 @@ task compile(dependsOn: ['compileBobLight']) {
 
 task createExternalLibsLightJar(type: Jar, dependsOn: compileSrc) {
     archiveFileName = 'external-libs-light.jar'
-    destinationDirectory = file("${project.bobDir}/tmp")
+    destinationDirectory = file("${bobDir}/tmp")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     from {
-        fileTree(dir: "${project.bobDir}/lib", include: '*.jar', exclude: 'android.jar').collect { zipTree(it) }
+        fileTree(dir: "${bobDir}/lib", include: '*.jar', exclude: 'android.jar').collect { zipTree(it) }
     }
 
-    inputs.files(fileTree(dir: "${project.bobDir}/lib", include: '*.jar', exclude: 'android.jar').files)
-    outputs.file("${project.bobDir}/tmp/external-libs-light.jar")
+    inputs.files(fileTree(dir: "${bobDir}/lib", include: '*.jar', exclude: 'android.jar').files)
+    outputs.file("${bobDir}/tmp/external-libs-light.jar")
 
     doLast {
-        if (!file("${project.bobDir}/tmp/external-libs-light.jar").exists()) {
-            throw new RuntimeException("File '${project.bobDir}/tmp/external-libs-light.jar' was not created")
+        if (!file("${bobDir}/tmp/external-libs-light.jar").exists()) {
+            throw new RuntimeException("File '${bobDir}/tmp/external-libs-light.jar' was not created")
         } else {
             println "external-libs-light.jar successfully created"
         }
@@ -493,13 +500,13 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
     dependsOn privateBobPluginJarTasks
 
     archiveFileName = 'bob-light.jar'
-    destinationDirectory = file("${project.bobDir}/dist")
+    destinationDirectory = file("${bobDir}/dist")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     // Engine cross-builds install host compiler libraries into DYNAMO_HOME.
     // Package those fresh artifacts before any potentially stale staged copies.
     from {
-        fileTree(project.dynamoHome) {
+        fileTree(dynamoHome) {
             include 'lib/**/*texc_shared*',
                     'lib/**/*modelc_shared*',
                     'lib/**/*shaderc_shared*',
@@ -507,10 +514,10 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
             exclude '**/*dSYM.zip'
         }
     }
-    from(project.classesDir) {
+    from(classesDir) {
         exclude 'private_plugins/**'
     }
-    from fileTree(project.bobDir) {
+    from fileTree(bobDir) {
         include 'lib/**/*texc_shared*',
                 'lib/**/*modelc_shared*',
                 'lib/**/*shaderc_shared*',
@@ -519,7 +526,7 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
         exclude '**/*dSYM.zip',
                 'tmp/**'
     }
-    from fileTree(project.bobDir) {
+    from fileTree(bobDir) {
         include 'libexec/**/glslang*',
                 'libexec/**/tint*',
                 'libexec/**/gltf_validator*',
@@ -529,12 +536,12 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
     }
 
     from {
-        zipTree(file("${project.bobDir}/tmp/external-libs-light.jar"))
+        zipTree(file("${bobDir}/tmp/external-libs-light.jar"))
     } {
         exclude '**/META-INF/**'
     }
 
-    outputs.file("${project.bobDir}/dist/bob-light.jar")
+    outputs.file("${bobDir}/dist/bob-light.jar")
 
     manifest {
         def attrs = [
@@ -556,11 +563,11 @@ task createBobLightJar(type: Jar, dependsOn: [compileBobLight, createExternalLib
                 'arm64-linux': 'libfontc_shared.so',
                 'x86_64-win32': 'fontc_shared.dll'
         ]
-        def hostFontcLibraryName = hostFontcLibraryNames[project.hostPlatform]
+        def hostFontcLibraryName = hostFontcLibraryNames[hostPlatform]
         if (!hostFontcLibraryName) {
-            throw new GradleException("Unsupported host platform: ${project.hostPlatform}")
+            throw new GradleException("Unsupported host platform: ${hostPlatform}")
         }
-        def hostFontcPath = "lib/${project.hostPlatform}/${hostFontcLibraryName}"
+        def hostFontcPath = "lib/${hostPlatform}/${hostFontcLibraryName}"
         def hasHostFontc = false
         new ZipFile(archiveFile.get().asFile).withCloseable { zipFile ->
             hasHostFontc = zipFile.getEntry(hostFontcPath) != null
@@ -576,24 +583,24 @@ task distBobLight(dependsOn: ['compileBobLight', 'createBobLightJar']) {
 
 task createExternalLibsBuiltinsJar(type: Jar, dependsOn: [compileSrc, compileGenerated]) {
     archiveFileName = 'external-libs-builtins.jar'
-    destinationDirectory = file("${project.bobDir}/tmp")
+    destinationDirectory = file("${bobDir}/tmp")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     Set<File> jarFiles = new HashSet<>()
 
-    jarFiles.addAll(fileTree(dir: "${project.bobDir}/lib/aws", include: '*.jar').files as Set<File>)
+    jarFiles.addAll(fileTree(dir: "${bobDir}/lib/aws", include: '*.jar').files as Set<File>)
 
-    jarFiles.addAll(fileTree(dir: "${project.bobDir}/lib", include: '*.jar', exclude: 'android.jar').files as Set<File>)
+    jarFiles.addAll(fileTree(dir: "${bobDir}/lib", include: '*.jar', exclude: 'android.jar').files as Set<File>)
 
     from {
         jarFiles.collect { zipTree(it) }
     }
 
     inputs.files(jarFiles)
-    outputs.file("${project.bobDir}/tmp/external-libs-builtins.jar")
+    outputs.file("${bobDir}/tmp/external-libs-builtins.jar")
 
     doLast {
-        def outputFile = file("${project.bobDir}/tmp/external-libs-builtins.jar")
+        def outputFile = file("${bobDir}/tmp/external-libs-builtins.jar")
         if (!outputFile.exists()) {
             throw new RuntimeException("File '${outputFile}' was not created")
         } else {
@@ -602,7 +609,7 @@ task createExternalLibsBuiltinsJar(type: Jar, dependsOn: [compileSrc, compileGen
     }
 }
 
-def bobJarFileTree = fileTree(project.bobDir) {
+def bobJarFileTree = fileTree(bobDir) {
     include 'lib/**/*texc_shared*',
             'lib/**/*modelc_shared*',
             'lib/**/*shaderc_shared*',
@@ -701,23 +708,23 @@ def addParallelArchiveEntry = { ParallelScatterZipCreator creator, Set<String> s
 task createBobJar(dependsOn: [compileBobLight, createExternalLibsBuiltinsJar, createLuaJitShareZip]) {
     dependsOn privateBobPluginJarTasks
 
-    def outputFile = file("${project.bobDir}/dist/bob.jar")
-    def bobClassesFileTree = fileTree(project.classesDir) {
+    def outputFile = file("${bobDir}/dist/bob.jar")
+    def bobClassesFileTree = fileTree(classesDir) {
         exclude 'private_plugins/**'
     }
 
     inputs.files(bobClassesFileTree)
     inputs.files(bobJarFileTree)
-    inputs.file("${project.bobDir}/tmp/external-libs-builtins.jar")
-    inputs.file("${project.bobDir}/lib/builtins.zip")
-    inputs.property('keep-bob-uncompressed', project.hasProperty('keep-bob-uncompressed'))
-    inputs.property('gradle-version', gradle.gradleVersion)
+    inputs.file("${bobDir}/tmp/external-libs-builtins.jar")
+    inputs.file("${bobDir}/lib/builtins.zip")
+    inputs.property('keep-bob-uncompressed', keepBobUncompressed)
+    inputs.property('gradle-version', gradleVersion)
     inputs.property('created-by', "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})")
     inputs.property('private-bob-plugin-class-path', privateBobPluginClassPath)
     outputs.file(outputFile)
 
     doLast {
-        int compressionMethod = project.hasProperty('keep-bob-uncompressed') ? ZipArchiveOutputStream.STORED : ZipArchiveOutputStream.DEFLATED
+        int compressionMethod = keepBobUncompressed ? ZipArchiveOutputStream.STORED : ZipArchiveOutputStream.DEFLATED
         int threadCount = Math.max(2, Runtime.getRuntime().availableProcessors())
         def executor = Executors.newFixedThreadPool(threadCount)
         def creator = new ParallelScatterZipCreator(executor)
@@ -756,17 +763,17 @@ task createBobJar(dependsOn: [compileBobLight, createExternalLibsBuiltinsJar, cr
 
             seenPaths.add('META-INF/MANIFEST.MF')
             bobClassesFileTree.files.sort { sourceFile ->
-                project.classesDir.toPath().relativize(sourceFile.toPath()).toString()
+                classesDir.toPath().relativize(sourceFile.toPath()).toString()
             }.each { sourceFile ->
-                addFile(project.classesDir, sourceFile)
+                addFile(classesDir, sourceFile)
             }
             bobJarFileTree.files.sort { sourceFile ->
-                project.bobDir.toPath().relativize(sourceFile.toPath()).toString()
+                bobDir.toPath().relativize(sourceFile.toPath()).toString()
             }.each { sourceFile ->
-                addFile(project.bobDir, sourceFile)
+                addFile(bobDir, sourceFile)
             }
-            addZipEntries(file("${project.bobDir}/tmp/external-libs-builtins.jar"), true)
-            addZipEntries(file("${project.bobDir}/lib/builtins.zip"), false)
+            addZipEntries(file("${bobDir}/tmp/external-libs-builtins.jar"), true)
+            addZipEntries(file("${bobDir}/lib/builtins.zip"), false)
 
             ZipArchiveOutputStream zipOutputStream = new ZipArchiveOutputStream(outputFile)
             try {
@@ -775,7 +782,7 @@ task createBobJar(dependsOn: [compileBobLight, createExternalLibsBuiltinsJar, cr
                 def manifestAttributes = [
                         'Main-Class': 'com.dynamo.bob.Bob',
                         'Enable-Native-Access': 'ALL-UNNAMED',
-                        'Gradle-Version': gradle.gradleVersion,
+                        'Gradle-Version': gradleVersion,
                         'Created-By': "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})"
                 ]
                 if (privateBobPluginClassPath) {
@@ -807,15 +814,15 @@ task createBobJar(dependsOn: [compileBobLight, createExternalLibsBuiltinsJar, cr
 
 task distBob(dependsOn: ['compile', 'createBobJar']) {
     doLast {
-        mkdir "${project.bobDir}/dist"
-        mkdir "${project.bobDir}/tmp"
+        mkdir "${bobDir}/dist"
+        mkdir "${bobDir}/tmp"
     }
 }
 
 task installBobLight(dependsOn: 'distBobLight') {
     doLast {
-        def sourceFile = file("${project.bobDir}/dist/bob-light.jar")
-        def destinationDir = file("${project.dynamoHome}/share/java")
+        def sourceFile = file("${bobDir}/dist/bob-light.jar")
+        def destinationDir = file("${dynamoHome}/share/java")
         def destinationFile = file("${destinationDir}/bob-light.jar")
         def temporaryFile = file("${destinationDir}/bob-light.jar.${System.nanoTime()}.tmp")
 
@@ -847,8 +854,8 @@ installBobLight.finalizedBy installPrivatePluginJars
 task install(dependsOn: 'distBob') {
     doLast {
         copy {
-            from "${project.bobDir}/dist/bob.jar"
-            into "${project.dynamoHome}/share/java"
+            from "${bobDir}/dist/bob.jar"
+            into "${dynamoHome}/share/java"
         }
     }
 }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/EngineArtifactsProvider.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/EngineArtifactsProvider.java
@@ -24,6 +24,7 @@ import com.dynamo.bob.util.TimeProfiler;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -139,7 +140,7 @@ public final class EngineArtifactsProvider {
 
     private static URL buildArtifactURL(String artifactsURL, String platformKey, String filename) throws IOException {
         try {
-            return new URL(String.format(artifactsURL + "%s/engine/%s/%s", EngineVersion.sha1, platformKey, filename));
+            return URI.create(String.format(artifactsURL + "%s/engine/%s/%s", EngineVersion.sha1, platformKey, filename)).toURL();
         } catch (Exception e) {
             throw new IOException(e);
         }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/Project.java
@@ -74,6 +74,7 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.ConnectException;
 import java.net.URI;
 import java.net.URL;
@@ -555,7 +556,7 @@ public class Project implements AutoCloseable {
         TimeProfiler.addData("type", "createTask");
         Builder builder;
         try {
-            builder = builderClass.newInstance();
+            builder = builderClass.getDeclaredConstructor().newInstance();
             builder.setProject(this);
             task = builder.create(inputResource);
             if (task != null) {
@@ -565,6 +566,15 @@ public class Project implements AutoCloseable {
             }
             circularDependencyChecker.remove(key);
             return task;
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof CompileExceptionError compileException) {
+                throw compileException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new RuntimeException(cause);
         } catch (CompileExceptionError e) {
             // Just pass CompileExceptionError on unmodified
             throw e;
@@ -971,7 +981,7 @@ public class Project implements AutoCloseable {
         }
 
         try {
-            return bundlerClass.newInstance();
+            return bundlerClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -1023,7 +1033,7 @@ public class Project implements AutoCloseable {
     public void registerTextureCompressors() {
         for (Class<? extends ITextureCompressor> klass : textureCompressorClasses) {
             try {
-                TextureCompression.registerCompressor(klass.newInstance());
+                TextureCompression.registerCompressor(klass.getDeclaredConstructor().newInstance());
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -1050,7 +1060,7 @@ public class Project implements AutoCloseable {
         Class<? extends IShaderCompiler> shaderCompilerClass = getShaderCompilerClass(platform);
         if (shaderCompilerClass != null) {
             try {
-                return shaderCompilerClass.newInstance();
+                return shaderCompilerClass.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProtoBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/ProtoBuilder.java
@@ -150,7 +150,7 @@ public abstract class ProtoBuilder<B extends GeneratedMessage.Builder<B>> extend
                     }
                 }
             } else if (isResource && value instanceof String) {
-                boolean isOptional = fieldDescriptor.isOptional();
+                boolean isOptional = !fieldDescriptor.isRequired() && !fieldDescriptor.isRepeated();
                 String resValue =  (String) value;
                 // We don't require optional fields to be filled
                 // if such a field has no value - just ignore it

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCache.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/cache/ResourceCache.java
@@ -16,6 +16,7 @@ package com.dynamo.bob.cache;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.net.MalformedURLException;
 import java.nio.file.Files;
@@ -55,7 +56,13 @@ public class ResourceCache {
 	}
 
 	private URL urlFromFile(File file) throws MalformedURLException {
-		return new URL(remoteCacheUrl + "/" + file.getName());
+		try {
+			return URI.create(remoteCacheUrl + "/" + file.getName()).toURL();
+		} catch (IllegalArgumentException e) {
+			MalformedURLException exception = new MalformedURLException(e.getMessage());
+			exception.initCause(e);
+			throw exception;
+		}
 	}
 
 	private void saveToLocalCache(File file, byte[] data) throws IOException {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollisionObjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/CollisionObjectBuilder.java
@@ -143,7 +143,7 @@ public class CollisionObjectBuilder extends ProtoBuilder<CollisionObjectDesc.Bui
             CollisionShape.Builder eb = CollisionShape.newBuilder().mergeFrom(messageBuilder.getEmbeddedCollisionShape());
             ValidateShapeTypes(eb.getShapesList(), shapeResource, isPhysics2D);
             Shape.Builder sb = Shape.newBuilder()
-                    .setShapeType(CollisionShape.Type.valueOf(cb.getShapeType().getNumber()))
+                    .setShapeType(CollisionShape.Type.forNumber(cb.getShapeType().getNumber()))
                     .setPosition(Point3.newBuilder())
                     .setRotation(Quat.newBuilder().setW(1))
                     .setIndex(eb.getDataCount())

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameObjectBuilder.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/GameObjectBuilder.java
@@ -79,7 +79,7 @@ public class GameObjectBuilder extends ProtoBuilder<PrototypeDesc.Builder> {
                 EmbeddedComponentDesc ec = EmbeddedComponentDesc.newBuilder()
                     .setId(componentDesc.getId())
                     .setType("sound")
-                    .setData(TextFormat.printToString(sd.build()))
+                    .setData(TextFormat.printer().printToString(sd.build()))
                     .build();
                 b.addEmbeddedComponents(ec);
             } else {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/pipeline/ModelUtil.java
@@ -1240,7 +1240,7 @@ public class ModelUtil {
             materialBuilder.setIndex(material.index);
             materialBuilder.setIsSkinned(material.isSkinned!=0);
             materialBuilder.setAlphaCutoff(material.alphaCutoff);
-            materialBuilder.setAlphaMode(Rig.AlphaMode.valueOf(material.alphaMode.getValue()));
+            materialBuilder.setAlphaMode(Rig.AlphaMode.forNumber(material.alphaMode.getValue()));
             materialBuilder.setDoubleSided(material.doubleSided);
             materialBuilder.setUnlit(material.unlit);
 
@@ -1631,7 +1631,7 @@ public class ModelUtil {
             meshBuilder.setIndices(ByteString.copyFrom(create16BitIndices(mesh.indices)));
         }
 
-        meshBuilder.setPrimitiveType(Rig.PrimitiveType.valueOf(mesh.primitiveType.getValue()));
+        meshBuilder.setPrimitiveType(Rig.PrimitiveType.forNumber(mesh.primitiveType.getValue()));
 
         if (mesh.material != null)
             meshBuilder.setMaterialIndex(mesh.material.index);

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/plugin/PluginScanner.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/plugin/PluginScanner.java
@@ -109,10 +109,10 @@ public class PluginScanner {
 				boolean isPrivate = Modifier.isPrivate(klass.getModifiers());
 				if (pluginBaseClass.isAssignableFrom(klass) && !isAbstract && !isPrivate) {
 					logger.fine("Found plugin " + className);
-					plugins.add((T)klass.newInstance());
+					plugins.add((T)klass.getDeclaredConstructor().newInstance());
 				}
 			}
-			catch(InstantiationException | IllegalAccessException e) {
+			catch(InstantiationException | IllegalAccessException | NoSuchMethodException e) {
 				throw new CompileExceptionError("Unable to create plugin " + className, e);
 			}
 			catch (Exception e) {

--- a/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TimeProfiler.java
+++ b/com.dynamo.cr/com.dynamo.cr.bob/src/com/dynamo/bob/util/TimeProfiler.java
@@ -245,7 +245,7 @@ public class TimeProfiler {
     }
 
     private static long getCurrentThreadId() {
-        return Thread.currentThread().getId();
+        return Thread.currentThread().threadId();
     }
 
     private static void setCurrentScope(ProfilingScope scope) {


### PR DESCRIPTION
Removes Java and Gradle deprecation warnings when building and testing Bob and Bob Light, while preserving extension compatibility and build error reporting.

### Technical changes

- Capture build settings during Gradle configuration to avoid accessing `Task.project` during execution.
- Replace deprecated Java and protobuf APIs for URLs, constructors, thread IDs, enum lookup, text formatting, and optional-field checks.
- Configure the standalone proto command before execution and update Gradle test logging syntax and JUnit matchers.
- Add regression tests for malformed cache URLs and builder constructor errors. Retain legacy compatibility tests with narrowly scoped deprecation suppressions.
- Validation: light/full builds pass with `--warning-mode fail`; all 549 Bob tests pass with host-platform bundler coverage on macOS ARM64, Java 25, and Gradle 9.1.0.